### PR TITLE
DEV-4419: New component: card-table-content & content-table

### DIFF
--- a/admin/config/sync/admin-role.strapi-super-admin.json
+++ b/admin/config/sync/admin-role.strapi-super-admin.json
@@ -329,6 +329,57 @@
     },
     {
       "action": "plugin::content-manager.explorer.create",
+      "subject": "api::card-table-content.card-table-content",
+      "properties": {
+        "fields": [
+          "title",
+          "contents",
+          "numberList",
+          "idContent"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "subject": "api::card-table-content.card-table-content",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "subject": "api::card-table-content.card-table-content",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "subject": "api::card-table-content.card-table-content",
+      "properties": {
+        "fields": [
+          "title",
+          "contents",
+          "numberList",
+          "idContent"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::card-table-content.card-table-content",
+      "properties": {
+        "fields": [
+          "title",
+          "contents",
+          "numberList",
+          "idContent"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
       "subject": "api::category.category",
       "properties": {
         "fields": [
@@ -876,7 +927,8 @@
           "content",
           "idContent",
           "media",
-          "titleSize"
+          "titleSize",
+          "table.content"
         ]
       },
       "conditions": []
@@ -902,7 +954,8 @@
           "content",
           "idContent",
           "media",
-          "titleSize"
+          "titleSize",
+          "table.content"
         ]
       },
       "conditions": []
@@ -916,7 +969,8 @@
           "content",
           "idContent",
           "media",
-          "titleSize"
+          "titleSize",
+          "table.content"
         ]
       },
       "conditions": []

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.content-table.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.content-table.json
@@ -1,0 +1,78 @@
+{
+  "key": "plugin_content_manager_configuration_components::shared.content-table",
+  "value": {
+    "uid": "shared.content-table",
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "id",
+      "defaultSortBy": "id",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "card_table_contents": {
+        "edit": {
+          "label": "card_table_contents",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "title"
+        },
+        "list": {
+          "label": "card_table_contents",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "contents": {
+        "edit": {
+          "label": "contents",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "title"
+        },
+        "list": {
+          "label": "contents",
+          "searchable": false,
+          "sortable": false
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "card_table_contents",
+        "contents"
+      ],
+      "edit": [
+        [
+          {
+            "name": "card_table_contents",
+            "size": 6
+          },
+          {
+            "name": "contents",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "isComponent": true
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_content_types##api##card-table-content.card-table-content.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_content_types##api##card-table-content.card-table-content.json
@@ -1,0 +1,139 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::api::card-table-content.card-table-content",
+  "value": {
+    "uid": "api::card-table-content.card-table-content",
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "idContent",
+      "defaultSortBy": "title",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "title": {
+        "edit": {
+          "label": "title",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "title",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "contents": {
+        "edit": {
+          "label": "contents",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "title"
+        },
+        "list": {
+          "label": "contents",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "numberList": {
+        "edit": {
+          "label": "numberList",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "numberList",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "idContent": {
+        "edit": {
+          "label": "idContent",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "idContent",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "edit": [
+        [
+          {
+            "name": "idContent",
+            "size": 6
+          },
+          {
+            "name": "title",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "contents",
+            "size": 6
+          }
+        ]
+      ],
+      "list": [
+        "id",
+        "title",
+        "contents",
+        "numberList"
+      ]
+    }
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_content_types##api##content.content.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_content_types##api##content.content.json
@@ -90,6 +90,20 @@
           "sortable": true
         }
       },
+      "table": {
+        "edit": {
+          "label": "table",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "table",
+          "searchable": false,
+          "sortable": false
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -120,6 +134,12 @@
       }
     },
     "layouts": {
+      "list": [
+        "id",
+        "idContent",
+        "title",
+        "table"
+      ],
       "edit": [
         [
           {
@@ -148,12 +168,13 @@
             "name": "media",
             "size": 6
           }
+        ],
+        [
+          {
+            "name": "table",
+            "size": 12
+          }
         ]
-      ],
-      "list": [
-        "id",
-        "idContent",
-        "title"
       ]
     }
   },

--- a/admin/config/sync/core-store.strapi_content_types_schema.json
+++ b/admin/config/sync/core-store.strapi_content_types_schema.json
@@ -2721,6 +2721,106 @@
       "actions": {},
       "lifecycles": {}
     },
+    "api::card-table-content.card-table-content": {
+      "kind": "collectionType",
+      "collectionName": "card_table_contents",
+      "info": {
+        "singularName": "card-table-content",
+        "pluralName": "card-table-contents",
+        "displayName": "Card Table Content",
+        "description": ""
+      },
+      "options": {
+        "draftAndPublish": true
+      },
+      "pluginOptions": {},
+      "attributes": {
+        "title": {
+          "type": "string"
+        },
+        "contents": {
+          "type": "relation",
+          "relation": "oneToMany",
+          "target": "api::content.content"
+        },
+        "numberList": {
+          "type": "integer"
+        },
+        "idContent": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "datetime"
+        },
+        "updatedAt": {
+          "type": "datetime"
+        },
+        "publishedAt": {
+          "type": "datetime",
+          "configurable": false,
+          "writable": true,
+          "visible": false
+        },
+        "createdBy": {
+          "type": "relation",
+          "relation": "oneToOne",
+          "target": "admin::user",
+          "configurable": false,
+          "writable": false,
+          "visible": false,
+          "useJoinTable": false,
+          "private": true
+        },
+        "updatedBy": {
+          "type": "relation",
+          "relation": "oneToOne",
+          "target": "admin::user",
+          "configurable": false,
+          "writable": false,
+          "visible": false,
+          "useJoinTable": false,
+          "private": true
+        }
+      },
+      "__schema__": {
+        "collectionName": "card_table_contents",
+        "info": {
+          "singularName": "card-table-content",
+          "pluralName": "card-table-contents",
+          "displayName": "Card Table Content",
+          "description": ""
+        },
+        "options": {
+          "draftAndPublish": true
+        },
+        "pluginOptions": {},
+        "attributes": {
+          "title": {
+            "type": "string"
+          },
+          "contents": {
+            "type": "relation",
+            "relation": "oneToMany",
+            "target": "api::content.content"
+          },
+          "numberList": {
+            "type": "integer"
+          },
+          "idContent": {
+            "type": "string"
+          }
+        },
+        "kind": "collectionType"
+      },
+      "modelType": "contentType",
+      "modelName": "card-table-content",
+      "connection": "default",
+      "uid": "api::card-table-content.card-table-content",
+      "apiName": "card-table-content",
+      "globalId": "CardTableContent",
+      "actions": {},
+      "lifecycles": {}
+    },
     "api::category.category": {
       "kind": "collectionType",
       "collectionName": "categories",
@@ -3554,6 +3654,11 @@
           ],
           "default": "small"
         },
+        "table": {
+          "type": "component",
+          "repeatable": false,
+          "component": "generic.table"
+        },
         "createdAt": {
           "type": "datetime"
         },
@@ -3628,6 +3733,11 @@
               "large"
             ],
             "default": "small"
+          },
+          "table": {
+            "type": "component",
+            "repeatable": false,
+            "component": "generic.table"
           }
         },
         "kind": "collectionType"
@@ -5282,7 +5392,8 @@
             "shared.slider",
             "generic.table",
             "pricing.cloud",
-            "generic.content-heading-container"
+            "generic.content-heading-container",
+            "shared.content-table"
           ]
         },
         "seo": {
@@ -5368,7 +5479,8 @@
               "shared.slider",
               "generic.table",
               "pricing.cloud",
-              "generic.content-heading-container"
+              "generic.content-heading-container",
+              "shared.content-table"
             ]
           },
           "seo": {

--- a/admin/config/sync/user-role.public.json
+++ b/admin/config/sync/user-role.public.json
@@ -43,6 +43,12 @@
       "action": "api::blog.blog.findOne"
     },
     {
+      "action": "api::card-table-content.card-table-content.find"
+    },
+    {
+      "action": "api::card-table-content.card-table-content.findOne"
+    },
+    {
       "action": "api::category.category.find"
     },
     {

--- a/admin/src/api/card-table-content/content-types/card-table-content/schema.json
+++ b/admin/src/api/card-table-content/content-types/card-table-content/schema.json
@@ -1,0 +1,30 @@
+{
+  "kind": "collectionType",
+  "collectionName": "card_table_contents",
+  "info": {
+    "singularName": "card-table-content",
+    "pluralName": "card-table-contents",
+    "displayName": "Card Table Content",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "contents": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::content.content"
+    },
+    "numberList": {
+      "type": "integer"
+    },
+    "idContent": {
+      "type": "string"
+    }
+  }
+}

--- a/admin/src/api/card-table-content/controllers/card-table-content.js
+++ b/admin/src/api/card-table-content/controllers/card-table-content.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * card-table-content controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::card-table-content.card-table-content');

--- a/admin/src/api/card-table-content/documentation/1.0.0/card-table-content.json
+++ b/admin/src/api/card-table-content/documentation/1.0.0/card-table-content.json
@@ -1,0 +1,507 @@
+{
+  "/card-table-contents": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CardTableContentListResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Card-table-content"
+      ],
+      "parameters": [
+        {
+          "name": "sort",
+          "in": "query",
+          "description": "Sort by attributes ascending (asc) or descending (desc)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "pagination[withCount]",
+          "in": "query",
+          "description": "Return page/pageSize (default: true)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "pagination[page]",
+          "in": "query",
+          "description": "Page number (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[pageSize]",
+          "in": "query",
+          "description": "Page size (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[start]",
+          "in": "query",
+          "description": "Offset value (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[limit]",
+          "in": "query",
+          "description": "Number of entities to return (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "fields",
+          "in": "query",
+          "description": "Fields to return (ex: title,author)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "populate",
+          "in": "query",
+          "description": "Relations to return",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "filters",
+          "in": "query",
+          "description": "Filters to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "object"
+          },
+          "style": "deepObject"
+        },
+        {
+          "name": "locale",
+          "in": "query",
+          "description": "Locale to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "operationId": "get/card-table-contents"
+    },
+    "post": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CardTableContentResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Card-table-content"
+      ],
+      "parameters": [],
+      "operationId": "post/card-table-contents",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CardTableContentRequest"
+            }
+          }
+        }
+      }
+    }
+  },
+  "/card-table-contents/{id}": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CardTableContentResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Card-table-content"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "get/card-table-contents/{id}"
+    },
+    "put": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CardTableContentResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Card-table-content"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "put/card-table-contents/{id}",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CardTableContentRequest"
+            }
+          }
+        }
+      }
+    },
+    "delete": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Card-table-content"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "delete/card-table-contents/{id}"
+    }
+  }
+}

--- a/admin/src/api/card-table-content/routes/card-table-content.js
+++ b/admin/src/api/card-table-content/routes/card-table-content.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * card-table-content router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::card-table-content.card-table-content');

--- a/admin/src/api/card-table-content/services/card-table-content.js
+++ b/admin/src/api/card-table-content/services/card-table-content.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * card-table-content service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::card-table-content.card-table-content');

--- a/admin/src/api/content/content-types/content/schema.json
+++ b/admin/src/api/content/content-types/content/schema.json
@@ -40,6 +40,11 @@
         "large"
       ],
       "default": "small"
+    },
+    "table": {
+      "type": "component",
+      "repeatable": false,
+      "component": "generic.table"
     }
   }
 }

--- a/admin/src/api/page/content-types/page/schema.json
+++ b/admin/src/api/page/content-types/page/schema.json
@@ -31,7 +31,8 @@
         "shared.slider",
         "generic.table",
         "pricing.cloud",
-        "generic.content-heading-container"
+        "generic.content-heading-container",
+        "shared.content-table"
       ]
     },
     "seo": {

--- a/admin/src/components/shared/content-table.json
+++ b/admin/src/components/shared/content-table.json
@@ -1,0 +1,20 @@
+{
+  "collectionName": "components_shared_content_tables",
+  "info": {
+    "displayName": "contentTable",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "card_table_contents": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::card-table-content.card-table-content"
+    },
+    "contents": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::content.content"
+    }
+  }
+}

--- a/web/deployments/deployment-dev.yml
+++ b/web/deployments/deployment-dev.yml
@@ -26,7 +26,7 @@ spec:
             value: "80"
       containers:
         - name: web
-          image: gatacaid/website:7.0.11-SNAPSHOT
+          image: gatacaid/website:7.0.12-SNAPSHOT
           imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true

--- a/web/deployments/deployment-dev.yml
+++ b/web/deployments/deployment-dev.yml
@@ -26,7 +26,7 @@ spec:
             value: "80"
       containers:
         - name: web
-          image: gatacaid/website:7.0.10-SNAPSHOT
+          image: gatacaid/website:7.0.11-SNAPSHOT
           imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
     "start": "gatsby develop",
     "typecheck": "tsc --noEmit"
   },
-  "version": "7.0.11",
+  "version": "7.0.12",
   "dependencies": {
     "@bakkenbaeck/gatsby-plugin-rename-routes": "^1.0.0",
     "@types/classnames": "^2.3.1",

--- a/web/src/components/atoms/strapi/StrapiAuthor.tsx
+++ b/web/src/components/atoms/strapi/StrapiAuthor.tsx
@@ -11,7 +11,7 @@ const teamImages = [
   images.ceoTeam,
   images.ctoTeam,
   images.csoTeam,
-  //images.businessTeam,
+  images.businessTeam,
   images.backendTeam,
   images.frontend1Team,
   images.designTeam,

--- a/web/src/interfaces/interfaces.tsx
+++ b/web/src/interfaces/interfaces.tsx
@@ -65,6 +65,7 @@ export interface PageModel extends PagePreviewModel {
 
 export interface InsideSectionsModel {
   id: any
+  idContent?: string
   title: string
   description: string
   switchLabel?: string
@@ -90,6 +91,7 @@ export interface InsideSectionsModel {
   feature_details?: any
   tiersDetail?: any
   contents?: any
+  card_table_contents?: any
 }
 export interface SeoModel {
   id: string

--- a/web/src/pages/useCasesSectors/web3/data/web3Data.json
+++ b/web/src/pages/useCasesSectors/web3/data/web3Data.json
@@ -6,7 +6,7 @@
         },
         "firstSection": {
             "contactButton": {
-                "label": "Try for free"
+                "label": "Contact us"
             },
             "description": "Bring the benefits of decentralization to both compliant and pseudonymous identity management",
             "title": "Web3"

--- a/web/src/pages/useCasesSectors/web3/sections/firstSection/FirstSection.tsx
+++ b/web/src/pages/useCasesSectors/web3/sections/firstSection/FirstSection.tsx
@@ -3,7 +3,7 @@ import cx from "classnames"
 import { ButtonModel } from "../../../../../interfaces/interfaces"
 import PurpleButton from "../../../../../components/atoms/buttons/purple/PurpleButton"
 import * as styles from "./firstSection.module.scss"
-import { gatacaStudioURL } from "../../../../../data/globalData"
+import { navigate } from "gatsby"
 
 export type ISectionProps = {
   title: string
@@ -24,7 +24,7 @@ const FirstSection: React.FC<ISectionProps> = props => {
         <div className={styles?.buttonContainer}>
           <PurpleButton
             label={contactButton?.label}
-            action={() => window.open(gatacaStudioURL, "_target")}
+            action={() => navigate("/company/contact")}
           />
         </div>
       </div>

--- a/web/src/templates/page/sections/AllSectionsTemplate.tsx
+++ b/web/src/templates/page/sections/AllSectionsTemplate.tsx
@@ -14,6 +14,7 @@ import Table from "./components/shared/table/Table"
 import CenteredHeader from "./components/generic/centeredHeader/CenteredHeader"
 import PricingInfo from "./components/pricing/pricingInfo/PricingInfo"
 import ContentHeadingContainer from "./components/generic/contentHeadingContainer/ContentHeadingContainer"
+import ContentTable from "./components/shared/contentTable/ContentTable"
 
 const AllSectionsTemplate: React.FC<PageModel> = props => {
   const [benefitsLoaded, setBenefitsLoaded] = React.useState<boolean>(false)
@@ -44,6 +45,7 @@ const AllSectionsTemplate: React.FC<PageModel> = props => {
           infoToggles,
           tier_tables,
           contents,
+          card_table_contents,
         } = item
 
         return (
@@ -154,6 +156,13 @@ const AllSectionsTemplate: React.FC<PageModel> = props => {
               <ContentHeadingContainer
                 listContent={contents?.data}
                 key={`content-heading-container_` + index}
+              />
+            )}
+            {__component === "shared.content-table" && (
+              <ContentTable
+                listContent={contents?.data}
+                tableOfContent={card_table_contents?.data}
+                key={`content-table_` + index}
               />
             )}
           </>

--- a/web/src/templates/page/sections/components/generic/centeredHeader/centeredHeader.module.scss
+++ b/web/src/templates/page/sections/components/generic/centeredHeader/centeredHeader.module.scss
@@ -10,7 +10,7 @@
     padding: 0 40px;
   }
   @include min-width($tabletMD) {
-    margin-bottom: 220px;
+    margin-bottom: 200px;
   } 
   @include min-width($desktopMD) {
     padding: 0 60px;

--- a/web/src/templates/page/sections/components/generic/contentHeadingContainer/ContentHeadingContainer.tsx
+++ b/web/src/templates/page/sections/components/generic/contentHeadingContainer/ContentHeadingContainer.tsx
@@ -3,6 +3,7 @@ import cx from "classnames"
 import * as styles from "./contentHeadingContainer.module.scss"
 import MarkDownContent from "../../../../../../components/elements/markDownContent/MarkDownContent"
 import StrapiImage from "../../../../../../components/atoms/images/StrapiImage"
+import ContentHeadingList from "./component/ContentHeadingList"
 
 export type ISectionProps = {
   listContent: {
@@ -26,50 +27,7 @@ const ContentHeadingContainer: React.FC<ISectionProps> = props => {
         "containerMaxWidth"
       )}`}
     >
-      {listContent?.map(item => {
-        const { id, idContent, title, content, media, titleSize } =
-          item.attributes
-
-        return (
-          <div id={idContent} key={`content_` + id}>
-            {titleSize === "small" && (
-              <h4 className={`${cx("heading4 marginBottom32")}`}>{title}</h4>
-            )}
-            {titleSize === "medium" && (
-              <h3 className={`${cx("heading3 marginBottom32")}`}>{title}</h3>
-            )}
-            {titleSize === "large" && (
-              <h1 className={`${cx("heading1 marginBottom32")}`}>{title}</h1>
-            )}
-
-            {content && <MarkDownContent content={content} />}
-
-            {media && (
-              <>
-                {media?.data?.attributes?.ext ===
-                (".jpeg" ||
-                  ".png" ||
-                  ".gif" ||
-                  ".scg" ||
-                  ".tiff" ||
-                  ".ico" ||
-                  ".dvu") ? (
-                  <div className={cx("marginBottom32")}>
-                    <StrapiImage image={media ? media : null} />
-                  </div>
-                ) : null}
-
-                {media?.data?.attributes?.ext ===
-                (".mp4" || ".mpeg" || ".mov" || "wmv" || ".avi" || ".flv") ? (
-                  <div className={cx("marginBottom32")}>
-                    <video src={media?.data?.attributes?.url} controls></video>
-                  </div>
-                ) : null}
-              </>
-            )}
-          </div>
-        )
-      })}
+      <ContentHeadingList listContent={listContent} />
     </section>
   )
 }

--- a/web/src/templates/page/sections/components/generic/contentHeadingContainer/ContentHeadingContainer.tsx
+++ b/web/src/templates/page/sections/components/generic/contentHeadingContainer/ContentHeadingContainer.tsx
@@ -46,8 +46,14 @@ const ContentHeadingContainer: React.FC<ISectionProps> = props => {
 
             {media && (
               <>
-                {media?.data?.attributes?.ext !=
-                (".mp4" || ".mpeg" || ".mov" || "wmv" || ".avi" || ".flv") ? (
+                {media?.data?.attributes?.ext ===
+                (".jpeg" ||
+                  ".png" ||
+                  ".gif" ||
+                  ".scg" ||
+                  ".tiff" ||
+                  ".ico" ||
+                  ".dvu") ? (
                   <div className={cx("marginBottom32")}>
                     <StrapiImage image={media ? media : null} />
                   </div>

--- a/web/src/templates/page/sections/components/generic/contentHeadingContainer/component/ContentHeadingList.tsx
+++ b/web/src/templates/page/sections/components/generic/contentHeadingContainer/component/ContentHeadingList.tsx
@@ -48,8 +48,8 @@ const ContentHeadingList: React.FC<ISectionProps> = props => {
             {media && (
               <>
                 {media?.data?.attributes?.ext ===
-                (".jpeg" ||
-                  ".png" ||
+                (".png" ||
+                  ".jpeg" ||
                   ".gif" ||
                   ".scg" ||
                   ".tiff" ||

--- a/web/src/templates/page/sections/components/generic/contentHeadingContainer/component/ContentHeadingList.tsx
+++ b/web/src/templates/page/sections/components/generic/contentHeadingContainer/component/ContentHeadingList.tsx
@@ -8,7 +8,6 @@ export type ISectionProps = {
   tableClassName?: string
   listContent: {
     attributes: {
-      id: any
       title?: string
       idContent?: string
       content?: string | any
@@ -28,11 +27,11 @@ const ContentHeadingList: React.FC<ISectionProps> = props => {
   return (
     <>
       {listContent?.map(item => {
-        const { id, idContent, title, content, media, titleSize, table } =
+        const { idContent, title, content, media, titleSize, table } =
           item.attributes
 
         return (
-          <div id={idContent} key={`content_` + id}>
+          <div id={idContent} key={`content_` + idContent}>
             {titleSize === "small" && (
               <h4 className={`${cx("heading4 marginBottom32")}`}>{title}</h4>
             )}

--- a/web/src/templates/page/sections/components/generic/contentHeadingContainer/component/ContentHeadingList.tsx
+++ b/web/src/templates/page/sections/components/generic/contentHeadingContainer/component/ContentHeadingList.tsx
@@ -1,0 +1,81 @@
+import * as React from "react"
+import cx from "classnames"
+import MarkDownContent from "../../../../../../../components/elements/markDownContent/MarkDownContent"
+import StrapiImage from "../../../../../../../components/atoms/images/StrapiImage"
+import Table from "../../../shared/table/Table"
+
+export type ISectionProps = {
+  tableClassName?: string
+  listContent: {
+    attributes: {
+      id: any
+      title?: string
+      idContent?: string
+      content?: string | any
+      media?: any
+      titleSize?: string
+      table?: {
+        content: any
+        className?: string
+      }
+    }
+  }[]
+}
+
+const ContentHeadingList: React.FC<ISectionProps> = props => {
+  const { tableClassName, listContent } = props
+
+  return (
+    <>
+      {listContent?.map(item => {
+        const { id, idContent, title, content, media, titleSize, table } =
+          item.attributes
+
+        return (
+          <div id={idContent} key={`content_` + id}>
+            {titleSize === "small" && (
+              <h4 className={`${cx("heading4 marginBottom32")}`}>{title}</h4>
+            )}
+            {titleSize === "medium" && (
+              <h3 className={`${cx("heading3 marginBottom32")}`}>{title}</h3>
+            )}
+            {titleSize === "large" && (
+              <h1 className={`${cx("heading1 marginBottom32")}`}>{title}</h1>
+            )}
+
+            {content && <MarkDownContent content={content} />}
+
+            {media && (
+              <>
+                {media?.data?.attributes?.ext ===
+                (".jpeg" ||
+                  ".png" ||
+                  ".gif" ||
+                  ".scg" ||
+                  ".tiff" ||
+                  ".ico" ||
+                  ".dvu") ? (
+                  <div className={cx("marginBottom32")}>
+                    <StrapiImage image={media ? media : null} />
+                  </div>
+                ) : null}
+
+                {media?.data?.attributes?.ext ===
+                (".mp4" || ".mpeg" || ".mov" || "wmv" || ".avi" || ".flv") ? (
+                  <div className={cx("marginBottom32")}>
+                    <video src={media?.data?.attributes?.url} controls></video>
+                  </div>
+                ) : null}
+              </>
+            )}
+            {table?.content && (
+              <Table className={tableClassName} content={table?.content} />
+            )}
+          </div>
+        )
+      })}
+    </>
+  )
+}
+
+export default ContentHeadingList

--- a/web/src/templates/page/sections/components/generic/header/Header.tsx
+++ b/web/src/templates/page/sections/components/generic/header/Header.tsx
@@ -27,12 +27,14 @@ const Header: React.FC<InsideSectionsModel> = props => {
             </div>
           )}
         </div>
-        <div className={styles.header__rightSide}>
-          <StrapiImage
-            className={styles.header__imageContainer}
-            image={hero ? hero : null}
-          />
-        </div>
+        {hero.data?.attributes?.url && (
+          <div className={styles.header__rightSide}>
+            <StrapiImage
+              className={styles.header__imageContainer}
+              image={hero ? hero : null}
+            />
+          </div>
+        )}
       </div>
     </section>
   )

--- a/web/src/templates/page/sections/components/products/benefits/benefits.module.scss
+++ b/web/src/templates/page/sections/components/products/benefits/benefits.module.scss
@@ -7,7 +7,7 @@
   margin: 162px 0 132px;
   padding: 0 20px;
   @include min-width($mobileXL) {
-    margin: 150px 0 220px;
+    margin: 150px 0 200px;
     padding: 0 40px;
   }
   @include min-width($desktopMD) {

--- a/web/src/templates/page/sections/components/products/listMedia/listMedia.module.scss
+++ b/web/src/templates/page/sections/components/products/listMedia/listMedia.module.scss
@@ -12,7 +12,7 @@
   gap: 32px;
 
   @include min-width($mobileXL) {
-    margin: 0 auto 220px;
+    margin: 0 auto 200px;
     padding: 0 40px;
     @include flex-direction(row);
     @include align-items(center);

--- a/web/src/templates/page/sections/components/shared/contentTable/ContentTable.tsx
+++ b/web/src/templates/page/sections/components/shared/contentTable/ContentTable.tsx
@@ -1,0 +1,82 @@
+import * as React from "react"
+import cx from "classnames"
+import * as styles from "./contentTable.module.scss"
+import TableOfContentContainer from "./elements/tableOfContentContainer/TableOfContentContainer"
+import ContentHeadingList from "../../generic/contentHeadingContainer/component/ContentHeadingList"
+
+export type ISectionProps = {
+  listContent: {
+    attributes: {
+      id: any
+      title?: string
+      idContent?: string
+      content?: string | any
+      media?: any
+      titleSize?: string
+      table?: {
+        content: any
+      }
+    }
+  }[]
+  tableOfContent: {
+    attributes: {
+      title: string
+      idContent: string
+      contents: {
+        data: {
+          attributes: {
+            idContent: string
+            title: string
+          }
+        }[]
+      }
+    }
+  }[]
+}
+
+const ContentTable: React.FC<ISectionProps> = props => {
+  const { listContent, tableOfContent } = props
+
+  const [tableOfContentOpenedID, setTableOfContentOpened] = React.useState("")
+
+  return (
+    <section className={`${styles?.contentTable} ${cx("containerMaxWidth")}`}>
+      {tableOfContent?.map((item, index) => {
+        return (
+          <TableOfContentContainer
+            open={tableOfContentOpenedID === item?.attributes?.idContent}
+            contents={item?.attributes?.contents}
+            item={item?.attributes}
+            setOptionOpened={setTableOfContentOpened}
+            className={styles?.showMobile}
+            key={"tableOfContent__" + index}
+          />
+        )
+      })}
+      <div className={`${styles?.contentTableContainer}`}>
+        {listContent && (
+          <div className={`${styles?.contentHeadingContainer}`}>
+            <ContentHeadingList
+              tableClassName={styles.tableContainer}
+              listContent={listContent}
+            />
+          </div>
+        )}
+        {tableOfContent?.map((item, index) => {
+          return (
+            <TableOfContentContainer
+              open={tableOfContentOpenedID === item?.attributes?.idContent}
+              contents={item?.attributes?.contents}
+              item={item?.attributes}
+              setOptionOpened={setTableOfContentOpened}
+              className={styles?.showDesktop}
+              key={"tableOfContent__" + index}
+            />
+          )
+        })}
+      </div>
+    </section>
+  )
+}
+
+export default ContentTable

--- a/web/src/templates/page/sections/components/shared/contentTable/contentTable.module.scss
+++ b/web/src/templates/page/sections/components/shared/contentTable/contentTable.module.scss
@@ -1,0 +1,63 @@
+@import "../../../../../../styles/mixins.scss";
+
+.contentTable{
+  margin-bottom: 132px;
+  @include min-width($mobileXL) {
+    margin-bottom: 200px;
+    padding: 0 20px;
+  }
+  @include min-width($desktopMD) {
+    padding: 0 40px;
+  }
+  .contentTableContainer {
+    @include flexbox();
+    @include flex-wrap(wrap);
+    @include justify-content(space-between);
+    padding: 0 20px;
+  
+    @include min-width($mobileXL) {
+      @include flex-wrap(nowrap);
+    }
+    @include min-width($desktopXL) {
+      padding: 0;
+    }
+    .contentHeadingContainer {
+      width: 100%;
+      @include min-width($tabletMD) {
+        width: calc(100% - 304px);
+      }
+      > div:not(:last-child) {
+        margin-bottom: 60px;
+      }
+    }
+  }
+  img {
+    max-width: 100%;
+    height: auto;
+  }
+  video {
+    max-width: 100%;
+  }
+  .tableContainer {
+    margin-bottom: 32px;
+    padding: 0;
+  }
+}
+
+.showDesktop {
+  display: none;
+  @include min-width($tabletMD) {
+    @include flexbox();
+    @include flex-direction(column);
+  }
+}
+
+.showMobile {
+  @include flexbox();
+  @include flex-direction(column);
+  margin-bottom: 32px;
+  @include min-width($tabletMD) {
+    display: none;
+    margin-bottom: 0;
+  }
+}

--- a/web/src/templates/page/sections/components/shared/contentTable/contentTable.module.scss.d.ts
+++ b/web/src/templates/page/sections/components/shared/contentTable/contentTable.module.scss.d.ts
@@ -1,0 +1,6 @@
+export const contentTable: string
+export const showDesktop: string
+export const showMobile: string
+export const contentTableContainer: string
+export const contentHeadingContainer: string
+export const tableContainer: string

--- a/web/src/templates/page/sections/components/shared/contentTable/elements/tableOfContentContainer/TableOfContentContainer.tsx
+++ b/web/src/templates/page/sections/components/shared/contentTable/elements/tableOfContentContainer/TableOfContentContainer.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import * as styles from "./tableOfContentContainer.module.scss"
+import { images } from "../../../../../../../../images/images"
+import TableOfContentOptions from "../tableOfContentOptions/TableOfContentOptions"
+
+export type ITableOfContentProps = {
+  item: {
+    title: string
+    idContent: string
+  }
+  contents: {
+    data: {
+      attributes: {
+        title: string
+        idContent: string
+      }
+    }[]
+  }
+  className?: string
+  open: boolean
+  setOptionOpened: (x: string) => void
+}
+const TableOfContentContainer: React.FC<ITableOfContentProps> = props => {
+  const { item, contents, className, open, setOptionOpened } = props
+  const isBrowser = typeof window !== "undefined"
+  const width = isBrowser ? window.innerWidth || Math.min(window.innerWidth) : 0
+  const mobile = width < 768
+  const desktop = width > 768
+  if (desktop) {
+    setOptionOpened(item?.idContent)
+  }
+
+  return (
+    <div
+      className={`${styles?.sectionMain__tableContentCol} ${
+        className && className
+      }`}
+      onClick={() =>
+        mobile && isBrowser ? setOptionOpened(!open ? item?.idContent : "") : {}
+      }
+    >
+      <div id={item?.idContent} className={styles?.title}>
+        <div className={styles?.title}>
+          <div>
+            <span>{item?.title}</span>
+
+            <img
+              className={styles.tableImage}
+              src={open ? images.chevronDownBig : images.chevronUp}
+            />
+          </div>
+        </div>
+        <TableOfContentOptions list={contents} open={open} />
+      </div>
+    </div>
+  )
+}
+
+export default TableOfContentContainer

--- a/web/src/templates/page/sections/components/shared/contentTable/elements/tableOfContentContainer/tableOfContentContainer.module.scss
+++ b/web/src/templates/page/sections/components/shared/contentTable/elements/tableOfContentContainer/tableOfContentContainer.module.scss
@@ -1,0 +1,45 @@
+@import "../../../../../../../../styles/colors.scss";
+@import "../../../../../../../../styles/mixins.scss";
+
+.sectionMain__tableContentCol {
+  @include min-width($tabletMD)  {
+    max-width: 252px;
+    min-width: 252px;
+  }
+  @include min-width($tabletXL) {
+    max-width: 272px;
+    min-width: 272px;
+  }
+  > div {
+    padding: 12px 20px;
+    background-color: $neutral200;
+    margin-top: -46px;
+    @include min-width($tabletMD) {
+      border-radius: 12px;
+      padding: 32px;
+      margin-top: 0px;
+    }
+  }
+  .title {
+    div {
+      @include flexbox();
+      @include justify-content(space-between);
+      @include align-items(center);
+      width: 100%;
+      span {
+        color: $neutral1000;
+        font-family: "Poppins";
+        font-size: 18px;
+        font-weight: 700;
+        line-height: 24px;
+        text-decoration: none;
+      }
+
+      &> .tableImage {
+        @include min-width($tabletMD) {
+          display: none;
+        }
+      }
+    }
+  }
+}

--- a/web/src/templates/page/sections/components/shared/contentTable/elements/tableOfContentContainer/tableOfContentContainer.module.scss.d.ts
+++ b/web/src/templates/page/sections/components/shared/contentTable/elements/tableOfContentContainer/tableOfContentContainer.module.scss.d.ts
@@ -1,0 +1,3 @@
+export const sectionMain__tableContentCol: string
+export const title: string
+export const tableImage: string

--- a/web/src/templates/page/sections/components/shared/contentTable/elements/tableOfContentOptions/TableOfContentOptions.tsx
+++ b/web/src/templates/page/sections/components/shared/contentTable/elements/tableOfContentOptions/TableOfContentOptions.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { Link } from "gatsby"
+import * as styles from "./tableOfContentOptions.module.scss"
+import cx from "classnames"
+
+export type ITableOfContenOptionProps = {
+  list: {
+    data: {
+      attributes: {
+        title: string
+        idContent: string
+      }
+    }[]
+  }
+  open: boolean
+}
+const TableOfContentOptions: React.FC<ITableOfContenOptionProps> = props => {
+  const { list, open } = props
+
+  return open ? (
+    <ol className={`${styles?.tableOfContenOptions} ${cx("marginTop24")}`}>
+      {list?.data.map((item, index) => {
+        const { idContent, title } = item?.attributes
+        const routePath = "#" + idContent
+
+        return (
+          <li className={cx("buttonSM")} key={"tableOfContent__" + index}>
+            <Link to={routePath || ""}>{title}</Link>
+          </li>
+        )
+      })}
+    </ol>
+  ) : null
+}
+
+export default TableOfContentOptions

--- a/web/src/templates/page/sections/components/shared/contentTable/elements/tableOfContentOptions/tableOfContentOptions.module.scss
+++ b/web/src/templates/page/sections/components/shared/contentTable/elements/tableOfContentOptions/tableOfContentOptions.module.scss
@@ -1,0 +1,8 @@
+@import "../../../../../../../../styles/colors.scss";
+@import "../../../../../../../../styles/mixins.scss";
+
+.tableOfContenOptions {
+  li:not(:last-child) {
+    margin-bottom: 24px;
+  }
+}

--- a/web/src/templates/page/sections/components/shared/contentTable/elements/tableOfContentOptions/tableOfContentOptions.module.scss.d.ts
+++ b/web/src/templates/page/sections/components/shared/contentTable/elements/tableOfContentOptions/tableOfContentOptions.module.scss.d.ts
@@ -1,0 +1,2 @@
+export const open: string
+export const tableOfContenOptions: string

--- a/web/src/templates/page/sections/components/shared/doubleColImageTextBg/doubleColImageTextBg.module.scss
+++ b/web/src/templates/page/sections/components/shared/doubleColImageTextBg/doubleColImageTextBg.module.scss
@@ -5,7 +5,7 @@
   margin-bottom: 132px;
   padding: 0 20px;
   @include min-width($mobileXL) {
-    margin-bottom: 220px;
+    margin-bottom: 200px;
     padding: 0 40px;
   }
   @include min-width($desktopMD) {

--- a/web/src/templates/page/sections/components/shared/doubleColTextImage/doubleColTextImage.module.scss
+++ b/web/src/templates/page/sections/components/shared/doubleColTextImage/doubleColTextImage.module.scss
@@ -5,7 +5,7 @@
   margin-bottom: 132px;
   padding: 0 20px;
   @include min-width($mobileXL) {
-    margin-bottom: 220px;
+    margin-bottom: 200px;
     padding: 0 40px;
   }
   @include min-width($desktopMD) {

--- a/web/src/templates/page/sections/components/shared/faqsSection/faqsSection.module.scss
+++ b/web/src/templates/page/sections/components/shared/faqsSection/faqsSection.module.scss
@@ -7,7 +7,7 @@
   padding: 0 20px;
   margin-top: 200px;
   @include min-width($mobileXL) {
-    margin-bottom: 220px;
+    margin-bottom: 200px;
     padding: 0 40px;
   }
   @include min-width($desktopMD) {

--- a/web/src/templates/page/sections/components/shared/table/Table.tsx
+++ b/web/src/templates/page/sections/components/shared/table/Table.tsx
@@ -5,14 +5,17 @@ import MarkDownContent from "../../../../../../components/elements/markDownConte
 
 export type ISectionProps = {
   content?: string
+  className?: string
 }
 const Table: React.FC<ISectionProps> = props => {
-  const { content } = props
+  const { content, className } = props
 
   return (
     <>
       <section
-        className={`${styles?.tableContainer} ${cx("containerMaxWidth")}`}
+        className={`${styles?.tableContainer} ${cx("containerMaxWidth")} ${
+          className && className
+        }`}
       >
         {content?.length && <MarkDownContent content={content} />}
       </section>

--- a/web/src/templates/page/sections/components/shared/table/table.module.scss
+++ b/web/src/templates/page/sections/components/shared/table/table.module.scss
@@ -8,7 +8,7 @@
   margin-bottom: 132px;
   @include min-width($mobileXL) {
     padding: 0 40px;
-    margin-bottom: 220px;
+    margin-bottom: 200px;
   }
   @include min-width($desktopMD) {
     padding: 0 60px;


### PR DESCRIPTION
JIRA:

[New component: card-table-content & content-table](https://gataca.atlassian.net/browse/DEV-4419)

DONE:
1. Content heading container: condition based on image formats accepted by strapi
2. header: only show col right side when we have content
3. card-table-content & content-table: new components based on [DS](https://www.figma.com/design/KT2IKvsPLSuX0keXXFCprD/Design-System---WEBSITE?node-id=8206-43542&m=dev). Note that for mobile: now we will have the table of content after the header (approved by design)
4. web3: fix copy/url in header's button
5. article: maintain Chiara image for blog authors (was erased by mistake in the author component and it's affecting https://gataca.io/blog/introducing-gataca-vouch/) - this is a momentary code, then it will be replaced by strapi data
6. Page section component: fix margin bottom space according to what has been determined by Tefy

RESULT:

3. https://www.dev.gataca.io/privacy-policy2/: made with strapi content


https://github.com/user-attachments/assets/72d78761-e873-46a0-ad31-03db0846cc5f


4. http://localhost:8000/use-cases/web3/
5. https://www.dev.gataca.io/blog/new_blog_october/

To debug in Strapi


https://github.com/user-attachments/assets/8275ff9e-cec2-4a59-827a-3ee35eb67e37



