### PR TITLE
DEV-4491: Hide Go to ES landing in terms pages

### DIFF
--- a/web/src/templates/page/pageTemplate.tsx
+++ b/web/src/templates/page/pageTemplate.tsx
@@ -36,7 +36,7 @@ const PageTemplate: React.FC = (props: any) => {
   return (
     <Layout seoData={pageData?.seo}>
       <>
-        <LocaleLink pageContext={props?.pageContext} />
+        {/* <LocaleLink pageContext={props?.pageContext} /> */}
         {pageData ? <AllSectionsTemplate {...pageData} /> : <PageSkeleton />}
         {pageData?.sections?.map(item => {
           const { __component, title, description, rightButton, leftButton } =


### PR DESCRIPTION
JIRA:
[Hide Go to ES landing in terms pages](https://gataca.atlassian.net/jira/software/c/projects/DEV/boards/26?assignee=6405a762c6e77744a1de59d6&selectedIssue=DEV-4526)

DONE:

Hide Link Component that allows redirection to landing page in ES in terms pages. For now we don’t have the translations in Spanish approved so no need of link until we have this content available.

RESULT:

https://www.dev.gataca.io/privacy-policy/