### PR TITLE
DEV-4544: Show Go to ES landing in terms pages & fix table markdown bg color

### DIFF
--- a/web/deployments/deployment-dev.yml
+++ b/web/deployments/deployment-dev.yml
@@ -26,7 +26,7 @@ spec:
             value: "80"
       containers:
         - name: web
-          image: gatacaid/website:7.1.0-SNAPSHOT
+          image: gatacaid/website:7.1.1-SNAPSHOT
           imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
     "start": "gatsby develop",
     "typecheck": "tsc --noEmit"
   },
-  "version": "7.1.0",
+  "version": "7.1.1",
   "dependencies": {
     "@bakkenbaeck/gatsby-plugin-rename-routes": "^1.0.0",
     "@types/classnames": "^2.3.1",

--- a/web/src/components/elements/markDownContent/markDownContent.module.scss
+++ b/web/src/components/elements/markDownContent/markDownContent.module.scss
@@ -115,6 +115,7 @@
       margin: 0 auto 20px;
       border-radius: 12px;
       border: 1px solid $neutral300;
+      background-color: $neutral100;
       > * {
         font-family: $base;
         font-size: 18px;

--- a/web/src/templates/page/pageTemplate.tsx
+++ b/web/src/templates/page/pageTemplate.tsx
@@ -36,7 +36,7 @@ const PageTemplate: React.FC = (props: any) => {
   return (
     <Layout seoData={pageData?.seo}>
       <>
-        {/* <LocaleLink pageContext={props?.pageContext} /> */}
+        <LocaleLink pageContext={props?.pageContext} />
         {pageData ? <AllSectionsTemplate {...pageData} /> : <PageSkeleton />}
         {pageData?.sections?.map(item => {
           const { __component, title, description, rightButton, leftButton } =


### PR DESCRIPTION
JIRA:

[Show Go to ES landing in terms pages & fix table markdown bg color](https://gataca.atlassian.net/jira/software/c/projects/DEV/boards/26?assignee=6405a762c6e77744a1de59d6&assignee=unassigned&assignee=62384b00ee1b5a0070275f07&selectedIssue=DEV-4544)

DONE:

- Recover link in terms pages to access pages in ES
- Markdown: add bg color to tables 

RESULT: 

https://www.dev.gataca.io/cookie-policy/