### PR TITLE
DEV-4466: Patterns - Components: General Cards Layout component & Logos Component

### DIFF
--- a/admin/config/sync/admin-role.strapi-super-admin.json
+++ b/admin/config/sync/admin-role.strapi-super-admin.json
@@ -3864,6 +3864,57 @@
     },
     {
       "action": "plugin::content-manager.explorer.create",
+      "subject": "api::logo-info.logo-info",
+      "properties": {
+        "fields": [
+          "idItem",
+          "logoInfo.idItem",
+          "logoInfo.title",
+          "logoInfo.image"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "subject": "api::logo-info.logo-info",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "subject": "api::logo-info.logo-info",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "subject": "api::logo-info.logo-info",
+      "properties": {
+        "fields": [
+          "idItem",
+          "logoInfo.idItem",
+          "logoInfo.title",
+          "logoInfo.image"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::logo-info.logo-info",
+      "properties": {
+        "fields": [
+          "idItem",
+          "logoInfo.idItem",
+          "logoInfo.title",
+          "logoInfo.image"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
       "subject": "api::logo.logo",
       "properties": {
         "fields": [

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.general-cards-layout.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.general-cards-layout.json
@@ -1,0 +1,118 @@
+{
+  "key": "plugin_content_manager_configuration_components::shared.general-cards-layout",
+  "value": {
+    "uid": "shared.general-cards-layout",
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "idItem",
+      "defaultSortBy": "idItem",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "idItem": {
+        "edit": {
+          "label": "idItem",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "idItem",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "button": {
+        "edit": {
+          "label": "button",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "button",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "heading": {
+        "edit": {
+          "label": "heading",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "idHeading"
+        },
+        "list": {
+          "label": "heading",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "mainCardContainer": {
+        "edit": {
+          "label": "mainCardContainer",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "mainCardContainer",
+          "searchable": false,
+          "sortable": false
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "idItem",
+        "button",
+        "heading"
+      ],
+      "edit": [
+        [
+          {
+            "name": "idItem",
+            "size": 6
+          },
+          {
+            "name": "heading",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "mainCardContainer",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "button",
+            "size": 12
+          }
+        ]
+      ]
+    },
+    "isComponent": true
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.highlight.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.highlight.json
@@ -16,8 +16,8 @@
         "edit": {},
         "list": {
           "label": "id",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "idItem": {

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.logo-container.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.logo-container.json
@@ -1,0 +1,98 @@
+{
+  "key": "plugin_content_manager_configuration_components::shared.logo-container",
+  "value": {
+    "uid": "shared.logo-container",
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "idItem",
+      "defaultSortBy": "idItem",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "idItem": {
+        "edit": {
+          "label": "idItem",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "idItem",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "columns": {
+        "edit": {
+          "label": "columns",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "columns",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "logo_info": {
+        "edit": {
+          "label": "logo_info",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "idItem"
+        },
+        "list": {
+          "label": "logo_info",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "idItem",
+        "columns",
+        "logo_info"
+      ],
+      "edit": [
+        [
+          {
+            "name": "idItem",
+            "size": 6
+          },
+          {
+            "name": "columns",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "logo_info",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "isComponent": true
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.logo.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.logo.json
@@ -1,0 +1,97 @@
+{
+  "key": "plugin_content_manager_configuration_components::shared.logo",
+  "value": {
+    "uid": "shared.logo",
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "idItem",
+      "defaultSortBy": "idItem",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "idItem": {
+        "edit": {
+          "label": "idItem",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "idItem",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "title": {
+        "edit": {
+          "label": "title",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "title",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "image": {
+        "edit": {
+          "label": "image",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "image",
+          "searchable": false,
+          "sortable": false
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "idItem",
+        "title",
+        "image"
+      ],
+      "edit": [
+        [
+          {
+            "name": "idItem",
+            "size": 6
+          },
+          {
+            "name": "title",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "image",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "isComponent": true
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.logos-component.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.logos-component.json
@@ -1,0 +1,118 @@
+{
+  "key": "plugin_content_manager_configuration_components::shared.logos-component",
+  "value": {
+    "uid": "shared.logos-component",
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "idItem",
+      "defaultSortBy": "idItem",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "idItem": {
+        "edit": {
+          "label": "idItem",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "idItem",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "heading": {
+        "edit": {
+          "label": "heading",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "idHeading"
+        },
+        "list": {
+          "label": "heading",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "logoContainer": {
+        "edit": {
+          "label": "logoContainer",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "logoContainer",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "background": {
+        "edit": {
+          "label": "background",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "background",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "idItem",
+        "heading",
+        "logoContainer"
+      ],
+      "edit": [
+        [
+          {
+            "name": "idItem",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "heading",
+            "size": 6
+          },
+          {
+            "name": "background",
+            "size": 4
+          }
+        ],
+        [
+          {
+            "name": "logoContainer",
+            "size": 12
+          }
+        ]
+      ]
+    },
+    "isComponent": true
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_content_types##api##logo-info.logo-info.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_content_types##api##logo-info.logo-info.json
@@ -1,0 +1,106 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::api::logo-info.logo-info",
+  "value": {
+    "uid": "api::logo-info.logo-info",
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "idItem",
+      "defaultSortBy": "idItem",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "idItem": {
+        "edit": {
+          "label": "idItem",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "idItem",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "logoInfo": {
+        "edit": {
+          "label": "logoInfo",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "logoInfo",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "idItem",
+        "logoInfo",
+        "createdAt"
+      ],
+      "edit": [
+        [
+          {
+            "name": "idItem",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "logoInfo",
+            "size": 12
+          }
+        ]
+      ]
+    }
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/admin/config/sync/core-store.strapi_content_types_schema.json
+++ b/admin/config/sync/core-store.strapi_content_types_schema.json
@@ -6290,14 +6290,14 @@
             "shared.list-group",
             "shared.header-container",
             "shared.sub-heading-container",
-            "shared.card-container",
             "shared.carrousel-logos",
             "shared.highlight",
             "shared.full-width-card",
             "shared.text-media",
             "shared.video",
             "shared.dynamic-card-component",
-            "shared.dynamic-selector"
+            "shared.dynamic-selector",
+            "shared.general-cards-layout"
           ],
           "pluginOptions": {
             "i18n": {
@@ -6432,14 +6432,14 @@
               "shared.list-group",
               "shared.header-container",
               "shared.sub-heading-container",
-              "shared.card-container",
               "shared.carrousel-logos",
               "shared.highlight",
               "shared.full-width-card",
               "shared.text-media",
               "shared.video",
               "shared.dynamic-card-component",
-              "shared.dynamic-selector"
+              "shared.dynamic-selector",
+              "shared.general-cards-layout"
             ],
             "pluginOptions": {
               "i18n": {

--- a/admin/config/sync/core-store.strapi_content_types_schema.json
+++ b/admin/config/sync/core-store.strapi_content_types_schema.json
@@ -6147,6 +6147,92 @@
       "actions": {},
       "lifecycles": {}
     },
+    "api::logo-info.logo-info": {
+      "kind": "collectionType",
+      "collectionName": "logo_infos",
+      "info": {
+        "singularName": "logo-info",
+        "pluralName": "logo-infos",
+        "displayName": "Logo info"
+      },
+      "options": {
+        "draftAndPublish": true
+      },
+      "pluginOptions": {},
+      "attributes": {
+        "idItem": {
+          "type": "string"
+        },
+        "logoInfo": {
+          "type": "component",
+          "repeatable": true,
+          "component": "shared.logo"
+        },
+        "createdAt": {
+          "type": "datetime"
+        },
+        "updatedAt": {
+          "type": "datetime"
+        },
+        "publishedAt": {
+          "type": "datetime",
+          "configurable": false,
+          "writable": true,
+          "visible": false
+        },
+        "createdBy": {
+          "type": "relation",
+          "relation": "oneToOne",
+          "target": "admin::user",
+          "configurable": false,
+          "writable": false,
+          "visible": false,
+          "useJoinTable": false,
+          "private": true
+        },
+        "updatedBy": {
+          "type": "relation",
+          "relation": "oneToOne",
+          "target": "admin::user",
+          "configurable": false,
+          "writable": false,
+          "visible": false,
+          "useJoinTable": false,
+          "private": true
+        }
+      },
+      "__schema__": {
+        "collectionName": "logo_infos",
+        "info": {
+          "singularName": "logo-info",
+          "pluralName": "logo-infos",
+          "displayName": "Logo info"
+        },
+        "options": {
+          "draftAndPublish": true
+        },
+        "pluginOptions": {},
+        "attributes": {
+          "idItem": {
+            "type": "string"
+          },
+          "logoInfo": {
+            "type": "component",
+            "repeatable": true,
+            "component": "shared.logo"
+          }
+        },
+        "kind": "collectionType"
+      },
+      "modelType": "contentType",
+      "modelName": "logo-info",
+      "connection": "default",
+      "uid": "api::logo-info.logo-info",
+      "apiName": "logo-info",
+      "globalId": "LogoInfo",
+      "actions": {},
+      "lifecycles": {}
+    },
     "api::operation.operation": {
       "kind": "collectionType",
       "collectionName": "operations",
@@ -6297,7 +6383,8 @@
             "shared.video",
             "shared.dynamic-card-component",
             "shared.dynamic-selector",
-            "shared.general-cards-layout"
+            "shared.general-cards-layout",
+            "shared.logos-component"
           ],
           "pluginOptions": {
             "i18n": {
@@ -6439,7 +6526,8 @@
               "shared.video",
               "shared.dynamic-card-component",
               "shared.dynamic-selector",
-              "shared.general-cards-layout"
+              "shared.general-cards-layout",
+              "shared.logos-component"
             ],
             "pluginOptions": {
               "i18n": {

--- a/admin/config/sync/user-role.public.json
+++ b/admin/config/sync/user-role.public.json
@@ -190,6 +190,12 @@
       "action": "api::list-option.list-option.findOne"
     },
     {
+      "action": "api::logo-info.logo-info.find"
+    },
+    {
+      "action": "api::logo-info.logo-info.findOne"
+    },
+    {
       "action": "api::logo.logo.find"
     },
     {

--- a/admin/src/api/logo-info/content-types/logo-info/schema.json
+++ b/admin/src/api/logo-info/content-types/logo-info/schema.json
@@ -1,0 +1,23 @@
+{
+  "kind": "collectionType",
+  "collectionName": "logo_infos",
+  "info": {
+    "singularName": "logo-info",
+    "pluralName": "logo-infos",
+    "displayName": "Logo info"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "idItem": {
+      "type": "string"
+    },
+    "logoInfo": {
+      "type": "component",
+      "repeatable": true,
+      "component": "shared.logo"
+    }
+  }
+}

--- a/admin/src/api/logo-info/controllers/logo-info.js
+++ b/admin/src/api/logo-info/controllers/logo-info.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * logo-info controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::logo-info.logo-info');

--- a/admin/src/api/logo-info/documentation/1.0.0/logo-info.json
+++ b/admin/src/api/logo-info/documentation/1.0.0/logo-info.json
@@ -1,0 +1,507 @@
+{
+  "/logo-infos": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LogoInfoListResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Logo-info"
+      ],
+      "parameters": [
+        {
+          "name": "sort",
+          "in": "query",
+          "description": "Sort by attributes ascending (asc) or descending (desc)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "pagination[withCount]",
+          "in": "query",
+          "description": "Return page/pageSize (default: true)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "pagination[page]",
+          "in": "query",
+          "description": "Page number (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[pageSize]",
+          "in": "query",
+          "description": "Page size (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[start]",
+          "in": "query",
+          "description": "Offset value (default: 0)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "pagination[limit]",
+          "in": "query",
+          "description": "Number of entities to return (default: 25)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "fields",
+          "in": "query",
+          "description": "Fields to return (ex: title,author)",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "populate",
+          "in": "query",
+          "description": "Relations to return",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "filters",
+          "in": "query",
+          "description": "Filters to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "object"
+          },
+          "style": "deepObject"
+        },
+        {
+          "name": "locale",
+          "in": "query",
+          "description": "Locale to apply",
+          "deprecated": false,
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "operationId": "get/logo-infos"
+    },
+    "post": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LogoInfoResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Logo-info"
+      ],
+      "parameters": [],
+      "operationId": "post/logo-infos",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/LogoInfoRequest"
+            }
+          }
+        }
+      }
+    }
+  },
+  "/logo-infos/{id}": {
+    "get": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LogoInfoResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Logo-info"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "get/logo-infos/{id}"
+    },
+    "put": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LogoInfoResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Logo-info"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "put/logo-infos/{id}",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/LogoInfoRequest"
+            }
+          }
+        }
+      }
+    },
+    "delete": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Logo-info"
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "deprecated": false,
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "operationId": "delete/logo-infos/{id}"
+    }
+  }
+}

--- a/admin/src/api/logo-info/routes/logo-info.js
+++ b/admin/src/api/logo-info/routes/logo-info.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * logo-info router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::logo-info.logo-info');

--- a/admin/src/api/logo-info/services/logo-info.js
+++ b/admin/src/api/logo-info/services/logo-info.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * logo-info service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::logo-info.logo-info');

--- a/admin/src/api/page/content-types/page/schema.json
+++ b/admin/src/api/page/content-types/page/schema.json
@@ -44,7 +44,8 @@
         "shared.video",
         "shared.dynamic-card-component",
         "shared.dynamic-selector",
-        "shared.general-cards-layout"
+        "shared.general-cards-layout",
+        "shared.logos-component"
       ],
       "pluginOptions": {
         "i18n": {

--- a/admin/src/api/page/content-types/page/schema.json
+++ b/admin/src/api/page/content-types/page/schema.json
@@ -37,14 +37,14 @@
         "shared.list-group",
         "shared.header-container",
         "shared.sub-heading-container",
-        "shared.card-container",
         "shared.carrousel-logos",
         "shared.highlight",
         "shared.full-width-card",
         "shared.text-media",
         "shared.video",
         "shared.dynamic-card-component",
-        "shared.dynamic-selector"
+        "shared.dynamic-selector",
+        "shared.general-cards-layout"
       ],
       "pluginOptions": {
         "i18n": {

--- a/admin/src/components/shared/general-cards-layout.json
+++ b/admin/src/components/shared/general-cards-layout.json
@@ -1,0 +1,27 @@
+{
+  "collectionName": "components_shared_general_cards_layouts",
+  "info": {
+    "displayName": "GeneralCardsLayout"
+  },
+  "options": {},
+  "attributes": {
+    "idItem": {
+      "type": "string"
+    },
+    "button": {
+      "type": "component",
+      "repeatable": false,
+      "component": "generic.button"
+    },
+    "heading": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::heading.heading"
+    },
+    "mainCardContainer": {
+      "type": "component",
+      "repeatable": false,
+      "component": "shared.card-container"
+    }
+  }
+}

--- a/admin/src/components/shared/logo-container.json
+++ b/admin/src/components/shared/logo-container.json
@@ -1,0 +1,26 @@
+{
+  "collectionName": "components_shared_logo_containers",
+  "info": {
+    "displayName": "LogoContainer",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "idItem": {
+      "type": "string"
+    },
+    "columns": {
+      "type": "enumeration",
+      "enum": [
+        "four",
+        "five"
+      ],
+      "default": "five"
+    },
+    "logo_info": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::logo-info.logo-info"
+    }
+  }
+}

--- a/admin/src/components/shared/logo.json
+++ b/admin/src/components/shared/logo.json
@@ -1,0 +1,25 @@
+{
+  "collectionName": "components_shared_logos",
+  "info": {
+    "displayName": "Logo"
+  },
+  "options": {},
+  "attributes": {
+    "idItem": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "image": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false
+    }
+  }
+}

--- a/admin/src/components/shared/logos-component.json
+++ b/admin/src/components/shared/logos-component.json
@@ -1,0 +1,27 @@
+{
+  "collectionName": "components_shared_logos_components",
+  "info": {
+    "displayName": "LogosComponent",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "idItem": {
+      "type": "string"
+    },
+    "heading": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::heading.heading"
+    },
+    "logoContainer": {
+      "type": "component",
+      "repeatable": false,
+      "component": "shared.logo-container"
+    },
+    "background": {
+      "type": "boolean",
+      "default": false
+    }
+  }
+}

--- a/web/deployments/deployment-dev.yml
+++ b/web/deployments/deployment-dev.yml
@@ -26,7 +26,7 @@ spec:
             value: "80"
       containers:
         - name: web
-          image: gatacaid/website:7.1.8-SNAPSHOT
+          image: gatacaid/website:7.1.9-SNAPSHOT
           imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
     "start": "gatsby develop",
     "typecheck": "tsc --noEmit"
   },
-  "version": "7.1.8",
+  "version": "7.1.9",
   "dependencies": {
     "@bakkenbaeck/gatsby-plugin-rename-routes": "^1.0.0",
     "@types/classnames": "^2.3.1",

--- a/web/src/interfaces/interfaces.tsx
+++ b/web/src/interfaces/interfaces.tsx
@@ -190,6 +190,7 @@ export interface InsideSectionsModel {
   selectorAlign?: string
   button?: ButtonModel
   mainCardContainer?: any
+  logoContainer?: any
 }
 
 export interface LocalizationsModel {

--- a/web/src/interfaces/interfaces.tsx
+++ b/web/src/interfaces/interfaces.tsx
@@ -171,7 +171,6 @@ export interface InsideSectionsModel {
   subHeading?: any
   columns?: string
   idItem?: string
-  card?: any
   loop?: boolean
   lightLogos?: boolean
   layout?: string
@@ -189,6 +188,8 @@ export interface InsideSectionsModel {
   selectorIllustration?: StrapiImageModel
   headingSelector?: any
   selectorAlign?: string
+  button?: ButtonModel
+  mainCardContainer?: any
 }
 
 export interface LocalizationsModel {

--- a/web/src/templates/page/sections/AllSectionsTemplate.tsx
+++ b/web/src/templates/page/sections/AllSectionsTemplate.tsx
@@ -24,6 +24,7 @@ import Video from "./components/shared/video/Video"
 import DynamicCardComponent from "./components/shared/dynamicCardComponent/DynamicCardComponent"
 import DynamicSelector from "./components/shared/dynamicSelector/DynamicSelector"
 import GeneralCardsLayout from "./components/shared/GeneralCardsLayout/GeneralCardsLayout"
+import LogosComponent from "./components/shared/LogosComponent/LogosComponent"
 
 const AllSectionsTemplate: React.FC<PageModel> = props => {
   const [benefitsLoaded, setBenefitsLoaded] = React.useState<boolean>(false)
@@ -87,6 +88,7 @@ const AllSectionsTemplate: React.FC<PageModel> = props => {
       selectorAlign,
       button,
       mainCardContainer,
+      logoContainer,
     } = item
 
     return (
@@ -267,6 +269,14 @@ const AllSectionsTemplate: React.FC<PageModel> = props => {
             image={image}
             video={video}
             color={color}
+          />
+        )}
+        {__component === "shared.logos-component" && (
+          <LogosComponent
+            idItem={idItem}
+            heading={heading?.data?.attributes?.heading}
+            logoContainer={logoContainer}
+            background={background}
           />
         )}
       </section>

--- a/web/src/templates/page/sections/AllSectionsTemplate.tsx
+++ b/web/src/templates/page/sections/AllSectionsTemplate.tsx
@@ -23,6 +23,7 @@ import TextMedia from "./components/shared/textMedia/TextMedia"
 import Video from "./components/shared/video/Video"
 import DynamicCardComponent from "./components/shared/dynamicCardComponent/DynamicCardComponent"
 import DynamicSelector from "./components/shared/dynamicSelector/DynamicSelector"
+import GeneralCardsLayout from "./components/shared/GeneralCardsLayout/GeneralCardsLayout"
 
 const AllSectionsTemplate: React.FC<PageModel> = props => {
   const [benefitsLoaded, setBenefitsLoaded] = React.useState<boolean>(false)
@@ -67,7 +68,6 @@ const AllSectionsTemplate: React.FC<PageModel> = props => {
       subHeading,
       columns,
       idItem,
-      card,
       loop,
       lightLogos,
       layout,
@@ -85,6 +85,8 @@ const AllSectionsTemplate: React.FC<PageModel> = props => {
       selectorIllustration,
       headingSelector,
       selectorAlign,
+      button,
+      mainCardContainer,
     } = item
 
     return (
@@ -207,11 +209,12 @@ const AllSectionsTemplate: React.FC<PageModel> = props => {
             <ChipGroup chipOptions={chip_options?.data} />
           </div>
         )}
-        {__component === "shared.card-container" && (
-          <MainCardContainer
+        {__component === "shared.general-cards-layout" && (
+          <GeneralCardsLayout
             idItem={idItem}
-            columns={columns}
-            card={card?.data?.attributes?.card}
+            heading={heading?.data?.attributes?.heading}
+            button={button}
+            mainCardContainer={mainCardContainer}
           />
         )}
         {__component === "shared.dynamic-selector" && (

--- a/web/src/templates/page/sections/components/shared/GeneralCardsLayout/GeneralCardsLayout.tsx
+++ b/web/src/templates/page/sections/components/shared/GeneralCardsLayout/GeneralCardsLayout.tsx
@@ -1,0 +1,109 @@
+import * as React from "react"
+import cx from "classnames"
+import {
+  ButtonModel,
+  HeadingModel,
+} from "../../../../../../interfaces/interfaces"
+import * as styles from "./generalCardsLayout.module.scss"
+import MainCardContainer from "../MainCardContainer/MainCardContainer"
+import Heading from "../Heading/Heading"
+import Button from "../../generic/button/Button"
+
+export type IGeneralCardsLayoutProps = {
+  idItem?: string
+  heading?: HeadingModel
+  button?: ButtonModel
+  mainCardContainer?: any
+}
+
+const GeneralCardsLayout: React.FC<IGeneralCardsLayoutProps> = props => {
+  const { idItem, heading, button, mainCardContainer } = props
+
+  return (
+    <div
+      id={idItem}
+      className={`${styles?.generalCardsLayout__container} ${cx(
+        "containerMaxWidth"
+      )} `}
+    >
+      {(heading ||
+        button?.label?.length ||
+        button?.icon?.data?.attributes?.url?.length) && (
+        <div className={styles.mainTitle__container}>
+          {heading && (
+            <Heading
+              idHeading={heading?.idHeading}
+              titleSize={heading?.titleSize}
+              align={heading?.align}
+              extraText={heading?.extraText}
+              title={heading?.title}
+              sectionName={heading?.sectionName}
+              content={heading?.content}
+              buttonGroup={heading?.buttonGroup?.buttons?.data}
+              list={heading?.list?.list_options?.data}
+              segmentedButton={heading?.segmentedButton?.buttons?.data}
+              table={heading?.table?.content}
+              className={styles?.headingCards}
+              chip={{
+                idChip: heading?.chip?.idChip,
+                text: heading?.chip?.text,
+                type: heading?.chip?.type,
+                form: heading?.chip?.form,
+                disabled: heading?.chip?.disabled,
+                color: heading?.chip?.color,
+                chipSize: heading?.chip?.chipSize,
+                leadingIcon: heading?.chip?.leadingIcon,
+                trailingIcon: heading?.chip?.trailingIcon,
+              }}
+              button={{
+                idButton: heading?.button?.idButton,
+                label: heading?.button?.label,
+                icon: heading?.button?.icon,
+                style: heading?.button?.style,
+                color: heading?.button?.color,
+                size: heading?.button?.size,
+                noPaddingText: heading?.button?.noPaddingText,
+                disabled: heading?.button?.disabled,
+                link: heading?.button?.link,
+                url: heading?.button?.url,
+                outsideWeb: heading?.button?.outsideWeb,
+                action: () => window.open(heading?.button?.url, "_blank"),
+              }}
+            />
+          )}
+          {(button?.label?.length ||
+            button?.icon?.data?.attributes?.url?.length) && (
+            <Button
+              idButton={button?.idButton}
+              className={cx("marginTop20")}
+              label={button?.label}
+              icon={button?.icon}
+              style={button?.style}
+              color={button?.color}
+              size={button?.size}
+              noPaddingText={button?.noPaddingText}
+              disabled={button?.disabled}
+              link={button?.link}
+              url={button?.url}
+              action={() =>
+                window?.open(
+                  button?.url,
+                  button?.outsideWeb ? "_blank" : "_self"
+                )
+              }
+            />
+          )}
+        </div>
+      )}
+      {mainCardContainer?.card?.data?.attributes?.card && (
+        <MainCardContainer
+          idItem={mainCardContainer?.idItem}
+          columns={mainCardContainer?.columns}
+          card={mainCardContainer?.card?.data?.attributes?.card}
+        />
+      )}
+    </div>
+  )
+}
+
+export default GeneralCardsLayout

--- a/web/src/templates/page/sections/components/shared/GeneralCardsLayout/generalCardsLayout.module.scss
+++ b/web/src/templates/page/sections/components/shared/GeneralCardsLayout/generalCardsLayout.module.scss
@@ -1,0 +1,29 @@
+@import "../../../../../../styles/colors.scss";
+@import "../../../../../../styles/mixins.scss";
+
+
+
+.generalCardsLayout__container {
+  margin-bottom: 132px;
+  padding: 0 20px;
+  @include flexbox();
+  @include flex-direction(column);
+  gap: 80px;
+  @include min-width($mobileXL) {
+    margin-bottom: 200px;
+    padding: 0 40px;
+  }
+  @include min-width($desktopMD) {
+    padding: 0 60px;
+  }
+  .mainTitle__container {
+    @include flexbox();
+    @include justify-content(space-between);
+    @include align-items(flex-end);
+    @include flex-wrap(wrap);
+    gap: 40px;
+    .headingCards {
+      max-width: 576px;
+    }
+  }
+}

--- a/web/src/templates/page/sections/components/shared/GeneralCardsLayout/generalCardsLayout.module.scss.d.ts
+++ b/web/src/templates/page/sections/components/shared/GeneralCardsLayout/generalCardsLayout.module.scss.d.ts
@@ -1,0 +1,3 @@
+export const generalCardsLayout__container: string
+export const mainTitle__container: string
+export const headingCards: string

--- a/web/src/templates/page/sections/components/shared/LogoContainer/LogoContainer.tsx
+++ b/web/src/templates/page/sections/components/shared/LogoContainer/LogoContainer.tsx
@@ -1,0 +1,44 @@
+import * as React from "react"
+import cx from "classnames"
+import * as styles from "./logoContainer.module.scss"
+import LogoComponent from "./component/Logo"
+
+export type ILogoContainerProps = {
+  className?: string
+  idItem?: string
+  columns?: string
+  logo?: any
+}
+
+const LogoContainer: React.FC<ILogoContainerProps> = props => {
+  const { className, idItem, columns, logo } = props
+
+  const columnStyles: Record<string, string> = {
+    four: styles?.fourColumns,
+    five: styles?.fiveColumns,
+  }
+
+  return (
+    <div
+      id={idItem}
+      className={`${styles.logo__container} ${className && className} ${cx(
+        columns ? columnStyles[columns] : ""
+      )} ${cx("containerMaxWidth")}`}
+    >
+      {logo?.map((item: any, index: number) => {
+        const { idItem, image, title } = item
+
+        return (
+          <LogoComponent
+            key={`logo__` + index}
+            idItem={idItem}
+            image={image}
+            title={title}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+export default LogoContainer

--- a/web/src/templates/page/sections/components/shared/LogoContainer/component/Logo.tsx
+++ b/web/src/templates/page/sections/components/shared/LogoContainer/component/Logo.tsx
@@ -1,0 +1,31 @@
+import * as React from "react"
+import cx from "classnames"
+import * as styles from "./logo.module.scss"
+import StrapiImage from "../../../../../../../components/atoms/images/StrapiImage"
+
+export type ILogoProps = {
+  className?: string
+  idItem?: string
+  image?: any
+  title?: string
+}
+
+const LogoComponent: React.FC<ILogoProps> = props => {
+  const { className, idItem, image, title } = props
+
+  return (
+    <div
+      id={idItem}
+      className={`${styles?.logo__container} ${className && className}`}
+    >
+      {image?.data?.attributes?.url ? (
+        <div className={styles?.imageContainer}>
+          <StrapiImage image={image ? image : null} />{" "}
+        </div>
+      ) : null}
+      {title?.length && <p className={cx("bodyBoldLG")}>{title}</p>}
+    </div>
+  )
+}
+
+export default LogoComponent

--- a/web/src/templates/page/sections/components/shared/LogoContainer/component/logo.module.scss
+++ b/web/src/templates/page/sections/components/shared/LogoContainer/component/logo.module.scss
@@ -1,0 +1,22 @@
+@import "../../../../../../../styles/colors.scss";
+@import "../../../../../../../styles/mixins.scss";
+@import "../../../../../../../styles/types";
+
+.logo__container {
+  @include flexbox();
+  @include flex-direction(column);
+  @include justify-content(flex-start);
+  @include align-items(center);
+  gap: 20px;
+  .imageContainer {
+    min-height: 60px;
+    img {
+      max-width: 100%;
+      height: auto;
+    }
+  }
+ 
+  p {
+    text-align: center;
+  }
+}

--- a/web/src/templates/page/sections/components/shared/LogoContainer/component/logo.module.scss.d.ts
+++ b/web/src/templates/page/sections/components/shared/LogoContainer/component/logo.module.scss.d.ts
@@ -1,0 +1,3 @@
+export const logo__container: string
+export const contentContainer: string
+export const imageContainer: string

--- a/web/src/templates/page/sections/components/shared/LogoContainer/logoContainer.module.scss
+++ b/web/src/templates/page/sections/components/shared/LogoContainer/logoContainer.module.scss
@@ -1,0 +1,65 @@
+@import "../../../../../../styles/colors.scss";
+@import "../../../../../../styles/mixins.scss";
+
+$paddingContainer: 0px;
+
+.logo__container {
+  width: 100%;
+  @include flexbox();
+  @include flex-direction(column);
+  @include justify-content(space-around);
+  @include flex-wrap(wrap);
+  @include align-items(center);
+  gap: 32px;
+  @include min-width($mobileXL) {
+    @include flex-direction(row);
+    @include align-items(stretch);
+  }
+  > div  {
+    max-width: 200px;
+    @include min-width($mobileXL) {
+      max-width: 100%;
+    }
+  }
+  &.fourColumns {
+    > div {
+      @include min-width($mobileXL) {
+        width: calc(calc(50% - $paddingContainer * 2) - calc(64px / 4));
+        @include flex(0, 0, calc(calc(50% - $paddingContainer * 2) - calc(64px / 4)))
+      }
+      @include min-width($tabletSM) {
+        width: calc(calc(100%/3) - $paddingContainer * 2 - calc(64px / 3));
+        @include flex(0, 0, calc(calc(100%/3) - $paddingContainer * 2 - calc(64px / 3)));
+    
+      }
+      @include min-width($desktopMD) {
+        width: calc(calc(25% - $paddingContainer * 2) - calc(64px / 2));
+        @include flex(0, 0, calc(calc(25% - $paddingContainer * 2) - calc(64px / 2)));
+      }
+    }
+  }
+  &.fiveColumns {
+    > div {
+      @include min-width($mobileXL) {
+        width: calc(calc(50% - $paddingContainer * 2) - calc(64px / 4));
+        @include flex(0, 0, calc(calc(50% - $paddingContainer * 2) - calc(64px / 4)))
+      }
+    
+      @include min-width($tabletSM) {
+        width: calc(calc(100%/3) - $paddingContainer * 2 - calc(64px / 3));
+        @include flex(0, 0, calc(calc(100%/3) - $paddingContainer * 2 - calc(64px / 3)));
+    
+      }
+      @include min-width($desktopMD) {
+        width: calc(calc(25% - $paddingContainer * 2) - calc(64px / 2));
+        @include flex(0, 0, calc(calc(25% - $paddingContainer * 2) - calc(64px / 2)));
+      }
+      @include min-width(1304px) {
+        width: calc(calc(20% - $paddingContainer * 2) - calc(64px / 2));
+        @include flex(0, 0, calc(calc(20% - $paddingContainer * 2) - calc(64px / 2)));
+      }
+
+    }
+  }
+}
+

--- a/web/src/templates/page/sections/components/shared/LogoContainer/logoContainer.module.scss.d.ts
+++ b/web/src/templates/page/sections/components/shared/LogoContainer/logoContainer.module.scss.d.ts
@@ -1,0 +1,4 @@
+export const logo__container: string
+export const logo: string
+export const fourColumns: string
+export const fiveColumns: string

--- a/web/src/templates/page/sections/components/shared/LogosComponent/LogosComponent.tsx
+++ b/web/src/templates/page/sections/components/shared/LogosComponent/LogosComponent.tsx
@@ -1,0 +1,78 @@
+import * as React from "react"
+import cx from "classnames"
+import { HeadingModel } from "../../../../../../interfaces/interfaces"
+import * as styles from "./logosComponent.module.scss"
+import Heading from "../Heading/Heading"
+import LogoContainer from "../LogoContainer/LogoContainer"
+
+export type ILogosComponentProps = {
+  idItem?: string
+  heading?: HeadingModel
+  logoContainer?: any
+  background?: boolean
+}
+
+const LogosComponent: React.FC<ILogosComponentProps> = props => {
+  const { idItem, heading, logoContainer, background } = props
+
+  return (
+    <div
+      id={idItem}
+      className={`${styles?.generalCardsLayout__container} ${
+        background ? styles?.backgroundDark : ""
+      } `}
+    >
+      {heading && (
+        <Heading
+          idHeading={heading?.idHeading}
+          titleSize={heading?.titleSize}
+          align={heading?.align}
+          extraText={heading?.extraText}
+          title={heading?.title}
+          sectionName={heading?.sectionName}
+          content={heading?.content}
+          buttonGroup={heading?.buttonGroup?.buttons?.data}
+          list={heading?.list?.list_options?.data}
+          segmentedButton={heading?.segmentedButton?.buttons?.data}
+          table={heading?.table?.content}
+          className={cx("containerMaxWidth")}
+          chip={{
+            idChip: heading?.chip?.idChip,
+            text: heading?.chip?.text,
+            type: heading?.chip?.type,
+            form: heading?.chip?.form,
+            disabled: heading?.chip?.disabled,
+            color: heading?.chip?.color,
+            chipSize: heading?.chip?.chipSize,
+            leadingIcon: heading?.chip?.leadingIcon,
+            trailingIcon: heading?.chip?.trailingIcon,
+          }}
+          button={{
+            idButton: heading?.button?.idButton,
+            label: heading?.button?.label,
+            icon: heading?.button?.icon,
+            style: heading?.button?.style,
+            color: heading?.button?.color,
+            size: heading?.button?.size,
+            noPaddingText: heading?.button?.noPaddingText,
+            disabled: heading?.button?.disabled,
+            link: heading?.button?.link,
+            url: heading?.button?.url,
+            outsideWeb: heading?.button?.outsideWeb,
+            action: () => window.open(heading?.button?.url, "_blank"),
+          }}
+        />
+      )}
+
+      {logoContainer && (
+        <LogoContainer
+          idItem={logoContainer?.idItem}
+          columns={logoContainer?.columns}
+          logo={logoContainer?.logo_info?.data?.attributes?.logoInfo}
+        />
+      )}
+    </div>
+  )
+}
+
+export default LogosComponent

--- a/web/src/templates/page/sections/components/shared/LogosComponent/logosComponent.module.scss
+++ b/web/src/templates/page/sections/components/shared/LogosComponent/logosComponent.module.scss
@@ -1,0 +1,34 @@
+@import "../../../../../../styles/colors.scss";
+@import "../../../../../../styles/mixins.scss";
+
+
+
+.generalCardsLayout__container {
+  margin-bottom: 132px;
+  padding: 0 20px;
+  @include flexbox();
+  @include flex-direction(column);
+  gap: 60px;
+  @include min-width($mobileXL) {
+    margin-bottom: 200px;
+    padding: 0 40px;
+  }
+  @include min-width($desktopMD) {
+    padding: 0 60px;
+  }
+  &.backgroundDark {
+    background-color: $neutral1000;
+    border-radius: 40px;
+    padding: 80px 20px;
+    @include min-width($mobileXL) {
+      padding: 120px 40px;
+    }
+    @include min-width($desktopMD) {
+      padding: 120px 60px;
+    }
+
+    > h1, h3, h4, h6, p {
+      color: $neutral100;
+    }
+  }
+}

--- a/web/src/templates/page/sections/components/shared/LogosComponent/logosComponent.module.scss.d.ts
+++ b/web/src/templates/page/sections/components/shared/LogosComponent/logosComponent.module.scss.d.ts
@@ -1,0 +1,4 @@
+export const generalCardsLayout__container: string
+export const mainTitle__container: string
+export const headingCards: string
+export const backgroundDark: string

--- a/web/src/templates/page/sections/components/shared/MainCardContainer/MainCardContainer.tsx
+++ b/web/src/templates/page/sections/components/shared/MainCardContainer/MainCardContainer.tsx
@@ -15,71 +15,70 @@ const MainCardContainer: React.FC<MainCardContainerModel> = props => {
   }
 
   return (
-    <div id={idItem} className={`${styles.card} ${cx("containerMaxWidth")} `}>
-      <div
-        className={`${styles.card__container} ${cx(
-          columns ? columnStyles[columns] : ""
-        )}`}
-      >
-        {card?.map((item: any, index: number) => {
-          const {
-            idCard,
-            upperIconOpened,
-            upperIconClosed,
-            numberIconText,
-            mainIcon,
-            title,
-            content,
-            size,
-            contentAlign,
-            moreContent,
-            button,
-            chip,
-          } = item
+    <div
+      id={idItem}
+      className={`${styles.card__container} ${cx(
+        columns ? columnStyles[columns] : ""
+      )}`}
+    >
+      {card?.map((item: any, index: number) => {
+        const {
+          idCard,
+          upperIconOpened,
+          upperIconClosed,
+          numberIconText,
+          mainIcon,
+          title,
+          content,
+          size,
+          contentAlign,
+          moreContent,
+          button,
+          chip,
+        } = item
 
-          return (
-            <Card
-              key={`card__` + index}
-              idCard={idCard}
-              upperIconOpened={upperIconOpened}
-              upperIconClosed={upperIconClosed}
-              numberIconText={numberIconText}
-              mainIcon={mainIcon}
-              title={title}
-              content={content}
-              size={size}
-              contentAlign={contentAlign}
-              moreContent={moreContent}
-              className={size === "small" ? styles?.smallCard : ""}
-              button={{
-                idButton: button?.idButton,
-                label: button?.label,
-                icon: button?.icon,
-                style: button?.style,
-                color: button?.color,
-                size: button?.size,
-                noPaddingText: button?.noPaddingText,
-                disabled: button?.disabled,
-                link: button?.link,
-                url: button?.url,
-                outsideWeb: button?.outsideWeb,
-                action: () => window.open(button?.url, "_blank"),
-              }}
-              chip={{
-                idChip: chip?.idChip,
-                text: chip?.text,
-                type: chip?.type,
-                form: chip?.form,
-                disabled: chip?.disabled,
-                color: chip?.color,
-                chipSize: chip?.chipSize,
-                leadingIcon: chip?.leadingIcon,
-                trailingIcon: chip?.trailingIcon,
-              }}
-            />
-          )
-        })}
-      </div>
+        return (
+          <Card
+            key={`card__` + index}
+            idCard={idCard}
+            upperIconOpened={upperIconOpened}
+            upperIconClosed={upperIconClosed}
+            numberIconText={numberIconText}
+            mainIcon={mainIcon}
+            title={title}
+            content={content}
+            size={size}
+            contentAlign={contentAlign}
+            moreContent={moreContent}
+            className={size === "small" ? styles?.smallCard : ""}
+            button={{
+              idButton: button?.idButton,
+              label: button?.label,
+              icon: button?.icon,
+              style: button?.style,
+              color: button?.color,
+              size: button?.size,
+              noPaddingText: button?.noPaddingText,
+              disabled: button?.disabled,
+              link: button?.link,
+              url: button?.url,
+              outsideWeb: button?.outsideWeb,
+              action: () => window.open(button?.url, "_blank"),
+            }}
+            chip={{
+              idChip: chip?.idChip,
+              text: chip?.text,
+              type: chip?.type,
+              form: chip?.form,
+              disabled: chip?.disabled,
+              color: chip?.color,
+              chipSize: chip?.chipSize,
+              leadingIcon: chip?.leadingIcon,
+              trailingIcon: chip?.trailingIcon,
+            }}
+          />
+        )
+      })}
     </div>
   )
 }

--- a/web/src/templates/page/sections/components/shared/MainCardContainer/mainCardContainer.module.scss
+++ b/web/src/templates/page/sections/components/shared/MainCardContainer/mainCardContainer.module.scss
@@ -4,18 +4,6 @@
 $paddingCard: 32px;
 $paddingSmallCard: 24px;
 
-.card{
-  margin-bottom:  132px;
-  padding: 0 20px;
-  @include min-width($mobileXL) {
-    margin-bottom: 200px;
-    padding: 0 40px;
-  }
-  @include min-width($desktopMD) {
-    padding: 0 60px;
-  }
-}
-
 .card__container {
   width: 100%;
   @include flexbox();
@@ -26,6 +14,7 @@ $paddingSmallCard: 24px;
   @include min-width($tabletMD) {
     @include flex-direction(row);
     @include align-items(flex-start);
+    @include align-items(stretch);
   }
   &.oneColumn {
     > div {


### PR DESCRIPTION
JIRA:

[Patterns - Components: General Cards Layout component & Logos Component](https://gataca.atlassian.net/browse/DEV-4466)

DONE:

- [General Cards Layout component](https://www.figma.com/design/KT2IKvsPLSuX0keXXFCprD/Design-System---WEBSITE?node-id=8469-15321&m=dev)
- [Logo Component](https://www.figma.com/design/KT2IKvsPLSuX0keXXFCprD/Design-System---WEBSITE?node-id=8644-16646&m=dev): new components Logo, Logo Container  & Logo Component (that includes all)

RESULT: https://www.dev.gataca.io/new-page/

General Cards Layout


https://github.com/user-attachments/assets/61ad5a4c-a89e-4253-92e8-60a127183618

Logos Component

Note: in the example with background active, don't take into account the color of the logos images, in case a design needs this background then the logos in white must be uploaded to Strapi.

https://github.com/user-attachments/assets/1404e045-2be0-4911-8517-e930d7351cab

