### PR TITLE
DEV-4612: Carrousel Logos & Header Container: add missing options

### DIFF
--- a/admin/config/sync/admin-role.strapi-editor.json
+++ b/admin/config/sync/admin-role.strapi-editor.json
@@ -1534,7 +1534,11 @@
           "buttonGroup.brand_buttons",
           "buttonGroup.button_icons",
           "table.content",
-          "lists"
+          "lists",
+          "showForm",
+          "formRegion",
+          "formPortalId",
+          "formId"
         ]
       },
       "conditions": []
@@ -1589,7 +1593,11 @@
           "buttonGroup.brand_buttons",
           "buttonGroup.button_icons",
           "table.content",
-          "lists"
+          "lists",
+          "showForm",
+          "formRegion",
+          "formPortalId",
+          "formId"
         ]
       },
       "conditions": []
@@ -1632,7 +1640,11 @@
           "buttonGroup.brand_buttons",
           "buttonGroup.button_icons",
           "table.content",
-          "lists"
+          "lists",
+          "showForm",
+          "formRegion",
+          "formPortalId",
+          "formId"
         ]
       },
       "conditions": []

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.carrousel-logos.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.carrousel-logos.json
@@ -62,6 +62,20 @@
           "searchable": false,
           "sortable": false
         }
+      },
+      "marginBottom": {
+        "edit": {
+          "label": "marginBottom",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "marginBottom",
+          "searchable": true,
+          "sortable": true
+        }
       }
     },
     "layouts": {
@@ -79,6 +93,10 @@
           },
           {
             "name": "loop",
+            "size": 4
+          },
+          {
+            "name": "marginBottom",
             "size": 4
           }
         ],

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.header-container.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.header-container.json
@@ -132,6 +132,34 @@
           "searchable": true,
           "sortable": true
         }
+      },
+      "headingRight": {
+        "edit": {
+          "label": "headingRight",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "headingRight",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "imageOutsideFrame": {
+        "edit": {
+          "label": "imageOutsideFrame",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "imageOutsideFrame",
+          "searchable": true,
+          "sortable": true
+        }
       }
     },
     "layouts": {
@@ -154,12 +182,22 @@
         ],
         [
           {
+            "name": "heading",
+            "size": 6
+          },
+          {
+            "name": "headingRight",
+            "size": 4
+          }
+        ],
+        [
+          {
             "name": "image",
             "size": 6
           },
           {
-            "name": "heading",
-            "size": 6
+            "name": "imageOutsideFrame",
+            "size": 4
           }
         ],
         [

--- a/admin/src/components/shared/carrousel-logos.json
+++ b/admin/src/components/shared/carrousel-logos.json
@@ -1,7 +1,8 @@
 {
   "collectionName": "components_shared_carrousel_logos",
   "info": {
-    "displayName": "CarrouselLogos"
+    "displayName": "CarrouselLogos",
+    "description": ""
   },
   "options": {},
   "attributes": {
@@ -17,6 +18,10 @@
       "type": "relation",
       "relation": "oneToMany",
       "target": "api::logo.logo"
+    },
+    "marginBottom": {
+      "type": "boolean",
+      "default": true
     }
   }
 }

--- a/admin/src/components/shared/header-container.json
+++ b/admin/src/components/shared/header-container.json
@@ -41,6 +41,14 @@
     },
     "formId": {
       "type": "string"
+    },
+    "headingRight": {
+      "type": "boolean",
+      "default": false
+    },
+    "imageOutsideFrame": {
+      "type": "boolean",
+      "default": true
     }
   }
 }

--- a/web/deployments/deployment-dev.yml
+++ b/web/deployments/deployment-dev.yml
@@ -26,7 +26,7 @@ spec:
             value: "80"
       containers:
         - name: web
-          image: ghcr.io/gataca-io/gataca.io/website:7.1.21-SNAPSHOT
+          image: ghcr.io/gataca-io/gataca.io/website:7.1.22-SNAPSHOT
           imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
     "start": "gatsby develop",
     "typecheck": "tsc --noEmit"
   },
-  "version": "7.1.21",
+  "version": "7.1.22",
   "dependencies": {
     "@bakkenbaeck/gatsby-plugin-rename-routes": "^1.0.0",
     "@types/classnames": "^2.3.1",

--- a/web/src/interfaces/interfaces.tsx
+++ b/web/src/interfaces/interfaces.tsx
@@ -205,6 +205,8 @@ export interface InsideSectionsModel {
   showForm?: boolean
   action_cards?: any
   marginBottom?: boolean
+  headingRight?: boolean
+  imageOutsideFrame?: boolean
 }
 
 export interface LocalizationsModel {
@@ -490,6 +492,8 @@ export interface HeaderContainerModel {
   formRegion?: string
   formPortalId?: string
   formId?: string
+  headingRight?: boolean
+  imageOutsideFrame?: boolean
 }
 
 export interface SubHeadingContainerModel {

--- a/web/src/interfaces/interfaces.tsx
+++ b/web/src/interfaces/interfaces.tsx
@@ -204,6 +204,7 @@ export interface InsideSectionsModel {
   formPortalId?: string
   showForm?: boolean
   action_cards?: any
+  marginBottom?: boolean
 }
 
 export interface LocalizationsModel {

--- a/web/src/templates/page/sections/AllSectionsTemplate.tsx
+++ b/web/src/templates/page/sections/AllSectionsTemplate.tsx
@@ -102,6 +102,8 @@ const AllSectionsTemplate: React.FC<PageModel> = props => {
       showForm,
       action_cards,
       marginBottom,
+      headingRight,
+      imageOutsideFrame,
     } = item
 
     return (
@@ -116,6 +118,8 @@ const AllSectionsTemplate: React.FC<PageModel> = props => {
             formRegion={formRegion}
             formPortalId={formPortalId}
             formId={formId}
+            headingRight={headingRight}
+            imageOutsideFrame={imageOutsideFrame}
           />
         )}
         {__component === "shared.carrousel-logos" && (

--- a/web/src/templates/page/sections/AllSectionsTemplate.tsx
+++ b/web/src/templates/page/sections/AllSectionsTemplate.tsx
@@ -101,6 +101,7 @@ const AllSectionsTemplate: React.FC<PageModel> = props => {
       formPortalId,
       showForm,
       action_cards,
+      marginBottom,
     } = item
 
     return (
@@ -122,6 +123,7 @@ const AllSectionsTemplate: React.FC<PageModel> = props => {
             list={logos?.data}
             lightLogos={lightLogos}
             loop={loop}
+            marginBottom={marginBottom}
           />
         )}
 

--- a/web/src/templates/page/sections/components/shared/carrouselLogos/CarrouselLogos.tsx
+++ b/web/src/templates/page/sections/components/shared/carrouselLogos/CarrouselLogos.tsx
@@ -6,6 +6,7 @@ export type IcarrouselLogosProps = {
   lightLogos?: boolean
   loop?: boolean
   className?: string
+  marginBottom?: boolean
   list: {
     attributes: {
       icon: any
@@ -17,13 +18,13 @@ export type IcarrouselLogosProps = {
 
 const timesToRepeatLogos = 15
 const CarrouselLogos: React.FC<IcarrouselLogosProps> = props => {
-  const { className, lightLogos, loop, list } = props
+  const { className, lightLogos, loop, marginBottom, list } = props
 
   return (
     <div
       className={`${className && className} ${styles.carrouselLogos} ${
         lightLogos ? styles.darkBackground : styles.lightBackground
-      }
+      } ${marginBottom ? styles?.marginBottom : ""}
       `}
     >
       {loop && loop ? (

--- a/web/src/templates/page/sections/components/shared/carrouselLogos/carrouselLogos.module.scss
+++ b/web/src/templates/page/sections/components/shared/carrouselLogos/carrouselLogos.module.scss
@@ -2,7 +2,12 @@
 @import "../../../../../../styles/mixins.scss";
 
 .carrouselLogos {
-  margin-bottom: 120px;
+  &.marginBottom {
+    margin-bottom: 132px;
+    @include min-width($mobileXL) {
+      margin-bottom: 200px;
+    }
+  }
   &.lightBackground {
     background-color: $neutral200;
   }

--- a/web/src/templates/page/sections/components/shared/carrouselLogos/carrouselLogos.module.scss.d.ts
+++ b/web/src/templates/page/sections/components/shared/carrouselLogos/carrouselLogos.module.scss.d.ts
@@ -7,3 +7,4 @@ export const clientsLogo__static: string
 export const clientsLogo__carrouselItem: string
 export const lightBackground: string
 export const darkBackground: string
+export const marginBottom: string

--- a/web/src/templates/page/sections/components/shared/headerContainer/HeaderContainer.tsx
+++ b/web/src/templates/page/sections/components/shared/headerContainer/HeaderContainer.tsx
@@ -17,6 +17,8 @@ const HeaderContainer: React.FC<HeaderContainerModel> = props => {
     formRegion,
     formPortalId,
     formId,
+    headingRight,
+    imageOutsideFrame,
   } = props
 
   const [formSubmitted, setFormSubmitted] = React.useState(false)
@@ -35,6 +37,8 @@ const HeaderContainer: React.FC<HeaderContainerModel> = props => {
         <div
           className={`${styles.header__heading} ${
             centerText ? styles?.centeredText : ""
+          } ${headingRight ? styles?.headingRight : ""} ${
+            imageOutsideFrame ? styles?.imageOutsideFrame : ""
           }`}
         >
           <Heading
@@ -47,15 +51,26 @@ const HeaderContainer: React.FC<HeaderContainerModel> = props => {
           />
         </div>
         {image?.data?.attributes?.url && (
-          <div className={styles.header__imageContainer}>
+          <div
+            className={`${styles.header__imageContainer} ${
+              headingRight ? styles?.headingRight : ""
+            } ${imageOutsideFrame ? styles?.imageOutsideFrame : ""}`}
+          >
             <StrapiImage
-              className={styles.header__image}
+              className={`${styles.header__image} ${
+                imageOutsideFrame ? styles?.imageOutsideFrame : ""
+              }`}
               image={image ? image : null}
             />
           </div>
         )}
         {showForm && formRegion && formPortalId && formId ? (
-          <div id="formContainer" className={styles?.form__container}>
+          <div
+            id="formContainer"
+            className={`${styles.form__container} ${
+              headingRight ? styles?.headingRight : ""
+            } ${imageOutsideFrame ? styles?.imageOutsideFrame : ""}`}
+          >
             <HubspotForm
               region={formRegion}
               portalId={formPortalId}

--- a/web/src/templates/page/sections/components/shared/headerContainer/headerContainer.module.scss
+++ b/web/src/templates/page/sections/components/shared/headerContainer/headerContainer.module.scss
@@ -35,13 +35,22 @@
 
 .header__heading {
   @include min-width($tabletMD) {
-    @include flex(0, 1, auto);
-    width: 100%;
+    @include flex(0, 1, calc(50% - 40px));
   }
   &.centeredText {
     @include min-width($tabletMD) {
       max-width: 778px;
+      @include flex(0, 1, auto);
       margin: 0 auto;
+    }
+  }
+  &.headingRight {
+    @include order(1);
+  }
+  &.imageOutsideFrame{
+    @include min-width($tabletMD) {
+      @include flex(0, 1, auto);
+      width: 100%;
     }
   }
 }
@@ -56,64 +65,128 @@
   width: calc(100% - 40px);
   @include min-width($tabletMD) {
     max-width: 400px;
+    @include flex(0, 1, calc(50% - 40px));
   }
   @include min-width($desktopXL) {
     max-width: 475px;
     width: 100%;
   }
+  &.headingRight {
+    @include order(0);
+  }
+  &:not(.imageOutsideFrame) {
+    @include flex(0, 1, calc(50% - 40px));
+  }
 }
 .header__imageContainer {
   width: 100%;
-  height: 88vw;
   @include flexbox();
   @include flex-direction(column);
   @include justify-content(center);
   @include align-items(center);
-  position: relative;
   @include min-width($tabletMD) {
-    position: inherit;
-    height: 100%;
-    width: calc(47% - 40px);
+    width: calc(50% - 40px);
+    @include align-items(flex-end);
   }
-  @include min-width($desktopMD) {
-    width: calc(52% - 40px);
-  }
-  .header__image {
+  &.imageOutsideFrame {
+    height: 88vw;
     position: relative;
-    top: 0;
-    right: -50px;
-    width: 100%;
-    @include min-width($mobileXL) {
-      right: -70px;
-    } 
+    @include align-items(center);
     @include min-width($tabletMD) {
-      max-height: 382px;
-      max-width: none;
-      width: auto;
-      right: 0;
-    }
-
-    @include min-width($desktopSM) {
-      max-height: 462px;
-      right: 0;
+      position: inherit;
+      height: 100%;
+      width: calc(47% - 40px);
     }
     @include min-width($desktopMD) {
-      max-height: 470px;
-      right: -60px;
+      width: calc(52% - 40px);
     }
-    @include min-width($desktopXL) {
-      max-height: 575px;
-      right: -40px;
+  }
+  &.headingRight {
+    @include order(0);
+    @include align-items(center);
+    @include min-width($tabletMD) {
+      @include align-items(flex-start);
     }
-    @include min-width($desktopXXL) {
-      right: -90px;
+    &.imageOutsideFrame {
+      height: 88vw;
+      position: relative;
+      @include align-items(center);
+  
+      @include min-width($tabletMD) {
+        position: inherit;
+        height: 100%;
+        width: calc(47% - 40px);
+      }
+  
+      @include min-width($desktopMD) {
+        width: calc(52% - 40px);
+      }
     }
-    @include min-width(1560px) {
-      right: 0;
+    .header__image {
+      &.imageOutsideFrame {
+        left: -50px;
+        @include min-width($mobileXL) {
+          left: -70px;
+        }
+        @include min-width($tabletMD) {
+          left: -10px;
+        }
+        @include min-width($desktopMD) {
+          left: -60px;
+        }
+        @include min-width($desktopXL) {
+          left: -40px;
+        }
+        @include min-width($desktopXXL) {
+          left: -90px;
+        }
+        @include min-width(1560px) {
+          left: 0;
+        }
+        @include min-width(1850px) {
+          left: -90px;
+        }
+      }
     }
-    @include min-width(1850px) {
-      max-height: 695px;
-      right: -90px;
+  }
+  .header__image {
+    max-width: 100%;
+    height: auto;
+    &.imageOutsideFrame {
+      position: relative;
+      top: 0;
+      right: -50px;
+      width: 100%;
+      @include min-width($mobileXL) {
+        right: -70px;
+      } 
+      @include min-width($tabletMD) {
+        max-height: 382px;
+        max-width: none;
+        width: auto;
+        right: -10px;
+      }
+      @include min-width($desktopSM) {
+        max-height: 462px;
+      }
+      @include min-width($desktopMD) {
+        max-height: 470px;
+        right: -60px;
+      }
+      @include min-width($desktopXL) {
+        max-height: 575px;
+        right: -40px;
+      }
+      @include min-width($desktopXXL) {
+        right: -90px;
+      }
+      @include min-width(1560px) {
+        right: 0;
+      }
+      @include min-width(1850px) {
+        max-height: 695px;
+        right: -90px;
+      }
     }
   }
 }

--- a/web/src/templates/page/sections/components/shared/headerContainer/headerContainer.module.scss.d.ts
+++ b/web/src/templates/page/sections/components/shared/headerContainer/headerContainer.module.scss.d.ts
@@ -6,3 +6,5 @@ export const header__image: string
 export const header__imageContainer: string
 export const form__container: string
 export const formActive: string
+export const headingRight: string
+export const imageOutsideFrame: string


### PR DESCRIPTION
JIRA: 
[Carrousel Logos & Header Container: add missing options](https://gataca.atlassian.net/browse/DEV-4612)

DONE:

- Carrousel Logos: add marginBottom boolean. [More info](https://www.figma.com/design/KT2IKvsPLSuX0keXXFCprD?node-id=8426-21914&m=dev#1063522849)

- HeaderContainer: Heading option to have it at the right or left & image option to have it outsideFrame [More info](https://www.figma.com/design/KT2IKvsPLSuX0keXXFCprD?node-id=8147-13636&m=dev#1063415913)

- Roles: add missing permites for Heading in Edit role

RESULT:

- Carrousel Logos: https://www.dev.gataca.io/pricing/


https://github.com/user-attachments/assets/bad56a15-d0d6-4ebb-9da4-aae79f161d75


- HeaderContainer: https://www.dev.gataca.io/new-page/

video: https://drive.google.com/file/d/1CpBa12BIsTzIGQ9xZbnEOy0i-KYMyWC8/view?usp=sharing

