### PR TITLE
DEV-4680: Strapi - changes in some components, new component & styles

### DIFF
--- a/admin/config/sync/admin-role.strapi-editor.json
+++ b/admin/config/sync/admin-role.strapi-editor.json
@@ -667,8 +667,7 @@
           "card.button.noPaddingText",
           "card.button.fullWidth",
           "card.upperIconClosed",
-          "card.upperIconOpened",
-          "card.moreContent"
+          "card.upperIconOpened"
         ]
       },
       "conditions": []
@@ -721,8 +720,7 @@
           "card.button.noPaddingText",
           "card.button.fullWidth",
           "card.upperIconClosed",
-          "card.upperIconOpened",
-          "card.moreContent"
+          "card.upperIconOpened"
         ]
       },
       "conditions": []
@@ -763,8 +761,7 @@
           "card.button.noPaddingText",
           "card.button.fullWidth",
           "card.upperIconClosed",
-          "card.upperIconOpened",
-          "card.moreContent"
+          "card.upperIconOpened"
         ]
       },
       "conditions": []

--- a/admin/config/sync/admin-role.strapi-super-admin.json
+++ b/admin/config/sync/admin-role.strapi-super-admin.json
@@ -866,7 +866,7 @@
           "card.button.fullWidth",
           "card.upperIconClosed",
           "card.upperIconOpened",
-          "card.moreContent"
+          "card.backContent"
         ]
       },
       "conditions": []
@@ -920,7 +920,7 @@
           "card.button.fullWidth",
           "card.upperIconClosed",
           "card.upperIconOpened",
-          "card.moreContent"
+          "card.backContent"
         ]
       },
       "conditions": []
@@ -962,7 +962,7 @@
           "card.button.fullWidth",
           "card.upperIconClosed",
           "card.upperIconOpened",
-          "card.moreContent"
+          "card.backContent"
         ]
       },
       "conditions": []

--- a/admin/config/sync/admin-role.strapi-super-admin.json
+++ b/admin/config/sync/admin-role.strapi-super-admin.json
@@ -4207,7 +4207,8 @@
           "lists",
           "showForm",
           "formRegion",
-          "formId"
+          "formId",
+          "listRow"
         ]
       },
       "conditions": []
@@ -4265,7 +4266,8 @@
           "lists",
           "showForm",
           "formRegion",
-          "formId"
+          "formId",
+          "listRow"
         ]
       },
       "conditions": []
@@ -4311,7 +4313,8 @@
           "lists",
           "showForm",
           "formRegion",
-          "formId"
+          "formId",
+          "listRow"
         ]
       },
       "conditions": []
@@ -5221,7 +5224,8 @@
           "pricingInfo.button.fullWidth",
           "pricingInfo.frecuencyYearly",
           "pricingInfo.extraInfo",
-          "pricingInfo.lists"
+          "pricingInfo.lists",
+          "pricingInfo.listRow"
         ]
       },
       "conditions": []
@@ -5267,7 +5271,8 @@
           "pricingInfo.button.fullWidth",
           "pricingInfo.frecuencyYearly",
           "pricingInfo.extraInfo",
-          "pricingInfo.lists"
+          "pricingInfo.lists",
+          "pricingInfo.listRow"
         ]
       },
       "conditions": []
@@ -5301,7 +5306,8 @@
           "pricingInfo.button.fullWidth",
           "pricingInfo.frecuencyYearly",
           "pricingInfo.extraInfo",
-          "pricingInfo.lists"
+          "pricingInfo.lists",
+          "pricingInfo.listRow"
         ]
       },
       "conditions": []

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.card.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.card.json
@@ -174,16 +174,16 @@
           "sortable": false
         }
       },
-      "moreContent": {
+      "backContent": {
         "edit": {
-          "label": "moreContent",
+          "label": "backContent",
           "description": "",
           "placeholder": "",
           "visible": true,
           "editable": true
         },
         "list": {
-          "label": "moreContent",
+          "label": "backContent",
           "searchable": true,
           "sortable": true
         }
@@ -245,7 +245,7 @@
         ],
         [
           {
-            "name": "moreContent",
+            "name": "backContent",
             "size": 6
           }
         ],

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.pricing-card.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.pricing-card.json
@@ -188,6 +188,21 @@
           "searchable": false,
           "sortable": false
         }
+      },
+      "listRow": {
+        "edit": {
+          "label": "listRow",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "idListOption"
+        },
+        "list": {
+          "label": "listRow",
+          "searchable": false,
+          "sortable": false
+        }
       }
     },
     "layouts": {
@@ -251,6 +266,10 @@
         [
           {
             "name": "lists",
+            "size": 6
+          },
+          {
+            "name": "listRow",
             "size": 6
           }
         ],

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_content_types##api##heading.heading.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_content_types##api##heading.heading.json
@@ -231,6 +231,21 @@
           "sortable": true
         }
       },
+      "listRow": {
+        "edit": {
+          "label": "listRow",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "idListOption"
+        },
+        "list": {
+          "label": "listRow",
+          "searchable": false,
+          "sortable": false
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -303,6 +318,12 @@
             "name": "lists",
             "size": 6
           },
+          {
+            "name": "listRow",
+            "size": 6
+          }
+        ],
+        [
           {
             "name": "showForm",
             "size": 4

--- a/admin/config/sync/core-store.strapi_content_types_schema.json
+++ b/admin/config/sync/core-store.strapi_content_types_schema.json
@@ -6212,7 +6212,7 @@
           "type": "string"
         },
         "title": {
-          "type": "string"
+          "type": "text"
         },
         "titleSize": {
           "type": "enumeration",
@@ -6326,7 +6326,7 @@
             "type": "string"
           },
           "title": {
-            "type": "string"
+            "type": "text"
           },
           "titleSize": {
             "type": "enumeration",

--- a/admin/config/sync/core-store.strapi_content_types_schema.json
+++ b/admin/config/sync/core-store.strapi_content_types_schema.json
@@ -6261,6 +6261,11 @@
         "formId": {
           "type": "string"
         },
+        "listRow": {
+          "type": "relation",
+          "relation": "oneToMany",
+          "target": "api::list-option.list-option"
+        },
         "createdAt": {
           "type": "datetime"
         },
@@ -6374,6 +6379,11 @@
           },
           "formId": {
             "type": "string"
+          },
+          "listRow": {
+            "type": "relation",
+            "relation": "oneToMany",
+            "target": "api::list-option.list-option"
           }
         },
         "kind": "collectionType"

--- a/admin/src/api/heading/content-types/heading/schema.json
+++ b/admin/src/api/heading/content-types/heading/schema.json
@@ -31,7 +31,7 @@
       "type": "string"
     },
     "title": {
-      "type": "string"
+      "type": "text"
     },
     "titleSize": {
       "type": "enumeration",

--- a/admin/src/api/heading/content-types/heading/schema.json
+++ b/admin/src/api/heading/content-types/heading/schema.json
@@ -79,6 +79,11 @@
     },
     "formId": {
       "type": "string"
+    },
+    "listRow": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::list-option.list-option"
     }
   }
 }

--- a/admin/src/components/shared/card.json
+++ b/admin/src/components/shared/card.json
@@ -78,7 +78,7 @@
         "audios"
       ]
     },
-    "moreContent": {
+    "backContent": {
       "type": "text"
     }
   }

--- a/admin/src/components/shared/pricing-card.json
+++ b/admin/src/components/shared/pricing-card.json
@@ -50,6 +50,11 @@
       "type": "relation",
       "relation": "oneToMany",
       "target": "api::list-option.list-option"
+    },
+    "listRow": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::list-option.list-option"
     }
   }
 }

--- a/web/src/components/elements/footer/Footer.tsx
+++ b/web/src/components/elements/footer/Footer.tsx
@@ -98,6 +98,7 @@ const Footer: React.FC = (props: any) => {
           {footerData?.linksList?.list_options?.data?.length > 0 && (
             <ListGroup
               listOptions={footerData?.linksList?.list_options?.data}
+              listRow
             />
           )}
         </div>

--- a/web/src/components/elements/footer/footer.module.scss
+++ b/web/src/components/elements/footer/footer.module.scss
@@ -64,12 +64,16 @@
         }
       }
       > div {
-        @include flex(0, 0, (calc(calc(100% / 2) - 32px)));
+        flex: 0 0 !important;
+        flex-basis: calc(calc(100% / 2) - 32px) !important;
+        min-width: auto !important;
         @include min-width($mobileXL) {
-          @include flex(0, 0, (calc(calc(100% / 3) - 22px)));
+          flex: 0 0 !important;
+          flex-basis: calc(calc(100% / 3) - 22px) !important;
         }
         @include min-width($tabletXL) {
-          @include flex(0, 0, (calc(calc(100% / 3) - 40px)));
+          flex: 0 0 !important;
+          flex-basis: calc(calc(100% / 3) - 40px) !important;
         }
       }
     }

--- a/web/src/components/elements/header/headerComponents/menuSubOption/MenuSubOption.tsx
+++ b/web/src/components/elements/header/headerComponents/menuSubOption/MenuSubOption.tsx
@@ -37,6 +37,7 @@ const MenuSubOption: React.FC<IMenuSubOptionProps> = props => {
           <ListGroup
             listOptions={item?.list_options?.data}
             className={styles?.listOptions_link}
+            listRow
           />
         </div>
       )}

--- a/web/src/interfaces/interfaces.tsx
+++ b/web/src/interfaces/interfaces.tsx
@@ -387,7 +387,7 @@ export interface CardModel {
   title?: string
   content?: any
   button?: ButtonModel
-  moreContent?: string
+  backContent?: string
 }
 
 export interface ActionCardModel {

--- a/web/src/interfaces/interfaces.tsx
+++ b/web/src/interfaces/interfaces.tsx
@@ -411,6 +411,7 @@ export interface PricingCardModel {
   idItem?: string
   titleAmountSize?: string
   lists?: any
+  listRow?: any
   name?: string
   description?: string
   frecuencyYearly?: string
@@ -465,6 +466,7 @@ export interface HeadingModel {
   button?: any
   buttonGroup?: any
   lists?: any
+  listRow?: any
   table?: any
   showForm?: boolean
   formRegion?: string

--- a/web/src/templates/page/sections/components/shared/FormLayout/FormLayout.tsx
+++ b/web/src/templates/page/sections/components/shared/FormLayout/FormLayout.tsx
@@ -126,7 +126,6 @@ const FormLayout: React.FC<ISectionProps> = props => {
             {headingSlot && (
               <Heading
                 {...headingSlot}
-                className={`${styles?.headingSlotContainer}`}
                 button={{
                   ...headingSlot?.button,
                   action: () => window.open(headingSlot?.button?.url, "_blank"),

--- a/web/src/templates/page/sections/components/shared/FormLayout/formLayout.module.scss
+++ b/web/src/templates/page/sections/components/shared/FormLayout/formLayout.module.scss
@@ -60,12 +60,6 @@
         @include min-width($desktopMD) {
           @include flex(0, 1, calc(50% - 16px));
         }
-        .headingSlotContainer {
-          @include flex-grow(1);
-          > div {
-            max-width: 576px;
-          }
-        }
       }
       .formLayout__rightSide {
         position: relative;

--- a/web/src/templates/page/sections/components/shared/FormLayout/formLayout.module.scss.d.ts
+++ b/web/src/templates/page/sections/components/shared/FormLayout/formLayout.module.scss.d.ts
@@ -5,7 +5,6 @@ export const formLayout__leftSide: string
 export const formLayout__rightSide: string
 export const image__container: string
 export const background: string
-export const headingSlotContainer: string
 export const greyBackground: string
 export const blackBackground: string
 export const form__container: string

--- a/web/src/templates/page/sections/components/shared/GeneralCardsLayout/generalCardsLayout.module.scss
+++ b/web/src/templates/page/sections/components/shared/GeneralCardsLayout/generalCardsLayout.module.scss
@@ -24,9 +24,6 @@
     gap: 40px;
     .headingCards {
       @include flex-grow(1);
-      > div {
-        max-width: 576px;
-      }
     }
   }
 }

--- a/web/src/templates/page/sections/components/shared/Heading/Heading.tsx
+++ b/web/src/templates/page/sections/components/shared/Heading/Heading.tsx
@@ -85,11 +85,17 @@ const Heading: React.FC<HeadingModel> = props => {
         {title?.length && (
           <>
             {titleSize === "large" ? (
-              <h1 className={cx("heading1")}>{title}</h1>
+              <h1>
+                <MarkDownContent content={title} />
+              </h1>
             ) : titleSize === "medium" ? (
-              <h3 className={cx("heading3")}>{title}</h3>
+              <h3>
+                <MarkDownContent content={title} />
+              </h3>
             ) : (
-              <h4 className={cx("heading4")}>{title}</h4>
+              <h4>
+                <MarkDownContent content={title} />
+              </h4>
             )}
           </>
         )}

--- a/web/src/templates/page/sections/components/shared/Heading/Heading.tsx
+++ b/web/src/templates/page/sections/components/shared/Heading/Heading.tsx
@@ -26,6 +26,7 @@ const Heading: React.FC<HeadingModel> = props => {
     button,
     buttonGroup,
     lists,
+    listRow,
     table,
     showForm,
     formRegion,
@@ -143,6 +144,13 @@ const Heading: React.FC<HeadingModel> = props => {
         )}
         {lists?.data?.length > 0 && (
           <ListGroup listOptions={lists?.data} className={cx("marginTop20")} />
+        )}
+        {listRow?.data?.length > 0 && (
+          <ListGroup
+            listOptions={listRow?.data}
+            listRow
+            className={cx("marginTop20")}
+          />
         )}
         {table?.content && (
           <Table

--- a/web/src/templates/page/sections/components/shared/Heading/heading.module.scss
+++ b/web/src/templates/page/sections/components/shared/Heading/heading.module.scss
@@ -3,7 +3,7 @@
 @import "../../../../../../styles/types";
 
 .heading__container {
-  &.alignRight, &.alignLeft {
+  &.alignRight {
     width: 100%;
   }
   > div {
@@ -24,12 +24,39 @@
     }
     &.alignRight {
       @include align-items(end);
-      p {
+      p, h1, h3, h4 {
         text-align: right;
       }
     }
     &.alignLeft {
       @include align-items(flex-start);
+    }
+    h1, h3, h4 {
+      p {
+        font-family: $custom;
+        color: $neutral1000;
+        margin-bottom: 0;
+        text-decoration: none;
+        font-weight: 700;
+      }
+    }
+    h1 {
+      p {
+        font-size: 56px;
+        line-height: 64px;
+      }
+    }
+    h3 {
+      p {
+        font-size: 40px;
+        line-height: 48px;
+      }
+    }
+    h4  {
+      p {
+        font-size: 32px;
+        line-height: 40px;
+      }
     }
     .heading__content {
       p {

--- a/web/src/templates/page/sections/components/shared/Highlight/highlight.module.scss
+++ b/web/src/templates/page/sections/components/shared/Highlight/highlight.module.scss
@@ -5,7 +5,12 @@
   &.blackBackground {
     background-color: $neutral1000;
     & > div > div > div {
-      & > h1, h6 {
+      & > h1, h3, h4 {
+        p {
+          color: $neutral100;
+        }
+      }
+      & > h6 {
         color: $neutral100;
       }
       & > div > div > p {
@@ -33,10 +38,6 @@
     @include min-width($desktopMD) {
       padding: 198px 60px 100px;
     }
-  }
-  > div > div {
-    max-width: 778px;
-    margin: 0 auto;
   }
   
 }

--- a/web/src/templates/page/sections/components/shared/PricingCard/PricingCard.tsx
+++ b/web/src/templates/page/sections/components/shared/PricingCard/PricingCard.tsx
@@ -11,6 +11,7 @@ const PricingCard: React.FC<PricingCardModel> = props => {
     idItem,
     titleAmountSize,
     lists,
+    listRow,
     name,
     description,
     frecuencyMonthly,
@@ -93,6 +94,11 @@ const PricingCard: React.FC<PricingCardModel> = props => {
       {lists?.data && (
         <div>
           <ListGroup listOptions={lists?.data} />
+        </div>
+      )}
+      {listRow?.data && (
+        <div>
+          <ListGroup listOptions={listRow?.data} listRow />
         </div>
       )}
 

--- a/web/src/templates/page/sections/components/shared/TeamLayout/teamLayout.module.scss
+++ b/web/src/templates/page/sections/components/shared/TeamLayout/teamLayout.module.scss
@@ -24,9 +24,6 @@
     gap: 40px;
     .headingCards {
       @include flex-grow(1);
-      > div {
-        max-width: 576px;
-      }
     }
   }
 }

--- a/web/src/templates/page/sections/components/shared/blogCard/BlogCard.tsx
+++ b/web/src/templates/page/sections/components/shared/blogCard/BlogCard.tsx
@@ -56,7 +56,9 @@ const BlogCard: React.FC<BlogPreviewModel> = props => {
         <div>
           {title?.length && <h5 className={cx("heading5")}>{title}</h5>}
           {date?.length && (
-            <p className={cx("bodyRegularMD")}>{moment(date).format("LL")}</p>
+            <p className={cx("bodyRegularMD marginTop8")}>
+              {moment(date).format("LL")}
+            </p>
           )}
         </div>
 
@@ -65,22 +67,22 @@ const BlogCard: React.FC<BlogPreviewModel> = props => {
             {content?.length && <MarkDownContent content={content} />}
           </div>
         )}
-      </div>
 
-      <Button
-        idButton={button?.idButton}
-        label={button?.label || "Read More"}
-        icon={button?.icon || images.chevronRight}
-        style={button?.style || "text"}
-        color={button?.color}
-        size={button?.size}
-        noPaddingText={button?.noPaddingText || true}
-        disabled={button?.disabled}
-        link={button?.link}
-        url={button?.url}
-        className={cx("marginTop8")}
-        action={() => window?.open(`/blog/${slugURL}`, "_self")}
-      />
+        <Button
+          idButton={button?.idButton}
+          label={button?.label || "Read More"}
+          icon={button?.icon || images.chevronRight}
+          style={button?.style || "text"}
+          color={button?.color}
+          size={button?.size}
+          noPaddingText={button?.noPaddingText || true}
+          disabled={button?.disabled}
+          link={button?.link}
+          url={button?.url}
+          className={cx("marginTop8")}
+          action={() => window?.open(`/blog/${slugURL}`, "_self")}
+        />
+      </div>
     </div>
   )
 }

--- a/web/src/templates/page/sections/components/shared/blogCard/blogCard.module.scss
+++ b/web/src/templates/page/sections/components/shared/blogCard/blogCard.module.scss
@@ -36,18 +36,34 @@
   .content__container {
     @include flexbox();
     @include flex-direction(column);
-    @include justify-content(flex-start);
+    @include justify-content(space-between);
     @include flex-wrap(wrap);
     gap: 20px;
+    @include min-width($tabletMD) {
+      @include flex(1 0 auto);
+    }
+    > div > h5 {
+      @include min-width($tabletMD) {
+        height: 96px;
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+    }
   }
   
 }
 
 .description {
-  height: 70px;
+  height: 72px;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
+  > div * {
+    font-size: 18px;
+  }
 }

--- a/web/src/templates/page/sections/components/shared/blogHighlightCard/blogHighlightCard.module.scss
+++ b/web/src/templates/page/sections/components/shared/blogHighlightCard/blogHighlightCard.module.scss
@@ -22,9 +22,6 @@
 
     .headingCards {
       @include flex-grow(1);
-      > div {
-        max-width: 576px;
-      }
     }
   }
 }

--- a/web/src/templates/page/sections/components/shared/card/Card.tsx
+++ b/web/src/templates/page/sections/components/shared/card/Card.tsx
@@ -20,7 +20,7 @@ const CardComponent: React.FC<CardModel> = props => {
     title,
     content,
     button,
-    moreContent,
+    backContent,
   } = props
 
   const iconSizeStyles: Record<string, string> = {
@@ -50,35 +50,32 @@ const CardComponent: React.FC<CardModel> = props => {
 
   const [showContent, setShowContent] = React.useState(false)
 
+  const backContentToShow = backContent?.length
+
   return (
     <div
       id={idCard}
       className={`${styles?.card__container} ${
         size ? cardSizeStyles[size] : ""
-      } ${showContent ? styles.showMoreContent : ""} ${className && className}`}
+      } ${showContent ? styles.showBackContent : ""} ${
+        backContentToShow ? styles?.backContentToShow : ""
+      } ${className && className}`}
+      onClick={() => {
+        backContentToShow && setShowContent(!showContent)
+      }}
     >
       {!showContent ? (
         <>
-          {upperIconClosed && (
-            <div
-              className={styles?.upperIcon}
-              onClick={() => {
-                setShowContent(!showContent)
-              }}
-            >
+          {upperIconClosed?.data?.attributes?.url && (
+            <div className={styles?.upperIcon}>
               <StrapiImage image={upperIconClosed ? upperIconClosed : null} />
             </div>
           )}
         </>
       ) : (
         <>
-          {upperIconOpened && (
-            <div
-              className={styles?.upperIcon}
-              onClick={() => {
-                setShowContent(!showContent)
-              }}
-            >
+          {upperIconOpened?.data?.attributes?.url && (
+            <div className={styles?.upperIcon}>
               <StrapiImage image={upperIconOpened ? upperIconOpened : null} />
             </div>
           )}
@@ -166,7 +163,7 @@ const CardComponent: React.FC<CardModel> = props => {
                 size ? contentSizeStyles[size] : "bodyRegularLG neutral1000"
               )}
             >
-              {moreContent}
+              {backContent}
             </p>
           </div>
         )}

--- a/web/src/templates/page/sections/components/shared/card/card.module.scss
+++ b/web/src/templates/page/sections/components/shared/card/card.module.scss
@@ -20,7 +20,6 @@
   .upperIcon {
     width: 100%;
     text-align: right;
-    cursor: pointer;
     img {
       max-width: 24px;
     }
@@ -28,8 +27,11 @@
   .numberIconText {
     color: $primary200;
   }
-  &.showMoreContent {
+  &.showBackContent {
     background-color: $neutral200;
+  }
+  &.backContentToShow {
+    cursor: pointer;
   }
   .contentContainer {
     position: relative;

--- a/web/src/templates/page/sections/components/shared/card/card.module.scss.d.ts
+++ b/web/src/templates/page/sections/components/shared/card/card.module.scss.d.ts
@@ -4,7 +4,8 @@ export const contentAlignCenter: string
 export const upperIcon: string
 export const numberIconText: string
 export const transitionContainer: string
-export const showMoreContent: string
+export const showBackContent: string
 export const contentContainer: string
 export const contentHide: string
 export const contentShow: string
+export const backContentToShow: string

--- a/web/src/templates/page/sections/components/shared/list/listGroup/ListGroup.tsx
+++ b/web/src/templates/page/sections/components/shared/list/listGroup/ListGroup.tsx
@@ -5,11 +5,12 @@ import List from "../components/List"
 
 export type IListGroupProps = {
   listOptions: any
+  listRow?: boolean
   className?: string
 }
 
 const ListGroup: React.FC<IListGroupProps> = props => {
-  const { listOptions, className } = props
+  const { listOptions, listRow, className } = props
 
   const spacingStyles: Record<string, string> = {
     small: styles?.spacingSmall,
@@ -28,7 +29,9 @@ const ListGroup: React.FC<IListGroupProps> = props => {
 
   return (
     <div
-      className={`${styles?.listGroup__container} ${className && className}`}
+      className={`${styles?.listGroup__container} ${
+        listRow ? styles.listRow : ""
+      } ${className && className}`}
     >
       {listOptions?.map((item: any, index: number) => {
         const { list, title, spacing, titleFontSize, titleFontWeight } =

--- a/web/src/templates/page/sections/components/shared/list/listGroup/listGroup.module.scss
+++ b/web/src/templates/page/sections/components/shared/list/listGroup/listGroup.module.scss
@@ -7,7 +7,17 @@
   @include justify-content(flex-start);
   @include flex-wrap(wrap);
   @include align-items(flex-start);
+  @include flex-direction(column);
   gap: 20px 40px;
+  &.listRow {
+    @include flex-direction(row);
+    gap: 20px 32px;
+    width: 100%;
+    .listGroup { 
+      @include flex(1, 0, 0);
+      min-width: 180px
+    }
+  }
   .listGroup {
     @include flexbox();
     @include justify-content(flex-start);

--- a/web/src/templates/page/sections/components/shared/list/listGroup/listGroup.module.scss.d.ts
+++ b/web/src/templates/page/sections/components/shared/list/listGroup/listGroup.module.scss.d.ts
@@ -7,3 +7,4 @@ export const boldFontWeight: string
 export const titleHeader: string
 export const mediumFontWeight: string
 export const smallTitle: string
+export const listRow: string

--- a/web/src/templates/page/sections/components/shared/sideCardsSlider/components/cardsContainer/CardsContainer.tsx
+++ b/web/src/templates/page/sections/components/shared/sideCardsSlider/components/cardsContainer/CardsContainer.tsx
@@ -17,62 +17,18 @@ const CardsContainer: React.FC<ICardsContainerProps> = props => {
   return (
     <div id={idItem} className={`${styles.cards__container}`}>
       {card?.map((item: any, index: number) => {
-        const {
-          idCard,
-          upperIconOpened,
-          upperIconClosed,
-          numberIconText,
-          mainIcon,
-          title,
-          content,
-          size,
-          contentAlign,
-          moreContent,
-          button,
-          chip,
-        } = item
-
         return (
           <div
             key={`card__` + index}
             style={{ width: cardWidth, height: cardHeight }}
           >
             <Card
-              idCard={idCard}
-              upperIconOpened={upperIconOpened}
-              upperIconClosed={upperIconClosed}
-              numberIconText={numberIconText}
-              mainIcon={mainIcon}
-              title={title}
-              content={content}
-              size={size}
-              contentAlign={contentAlign}
-              moreContent={moreContent}
+              {...item}
               button={{
-                idButton: button?.idButton,
-                label: button?.label,
-                icon: button?.icon,
-                style: button?.style,
-                color: button?.color,
-                size: button?.size,
-                noPaddingText: button?.noPaddingText,
-                disabled: button?.disabled,
-                link: button?.link,
-                url: button?.url,
-                outsideWeb: button?.outsideWeb,
-                action: () => window.open(button?.url, "_blank"),
+                ...item?.button,
+                action: () => window.open(item?.button?.url, "_blank"),
               }}
-              chip={{
-                idChip: chip?.idChip,
-                text: chip?.text,
-                type: chip?.type,
-                form: chip?.form,
-                disabled: chip?.disabled,
-                color: chip?.color,
-                chipSize: chip?.chipSize,
-                leadingIcon: chip?.leadingIcon,
-                trailingIcon: chip?.trailingIcon,
-              }}
+              chip={{ ...item?.chip }}
             />
           </div>
         )

--- a/web/src/templates/page/sections/components/shared/video/video.module.scss
+++ b/web/src/templates/page/sections/components/shared/video/video.module.scss
@@ -15,9 +15,6 @@
   }
   .video__heading {
     margin-bottom: 80px;
-    > div > div {
-      max-width: 778px;
-    }
   }
   .video__videoContainer {
     max-width: calc(1184px - 80px);


### PR DESCRIPTION
JIRA:

[Strapi: changes in some components, new component & styles](https://gataca.atlassian.net/browse/DEV-4680)

DONE:

- Heading: title as markdown to have the option of line break with html and delete max width in components.
- Card: backContent instead of moreContent & click in all card not only in upperIcon
- New component →  [listRow - new name listRow](https://www.figma.com/design/KT2IKvsPLSuX0keXXFCprD/Design-System---WEBSITE?node-id=9539-7231&m=dev) & add it to heading component & pricingCard slots. Adjustment in Menu & Footer when needed listRow
- BlogCard: fix title min-height, date space & font size content

RESULT: https://www.dev.gataca.io/new-page/

- Heading: 

![Screenshot 2025-01-22 at 11 27 30](https://github.com/user-attachments/assets/38b4b9d7-4e26-4640-bc5c-55c04e9ba1bc)
![Screenshot 2025-01-22 at 11 27 17](https://github.com/user-attachments/assets/5ed074d3-9adc-4902-9895-a7d48ccf3aff)

- Card: 

https://github.com/user-attachments/assets/86530e48-a21c-46ca-a47f-943afe72d4ff

- ListRow:

https://drive.google.com/file/d/1Jtsukv97lMxip-qAnC4uSytatdniup4k/view?usp=sharing


