### PR TITLE
DEV-4689: Fixes: dynamicSelector & sideCardsSlider

### DIFF
--- a/web/src/images/icons/singleFeatureMark.svg
+++ b/web/src/images/icons/singleFeatureMark.svg
@@ -1,5 +1,5 @@
-<svg width="81" height="32" viewBox="0 0 81 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="12" cy="20" r="6" fill="#4745B7"/>
-<circle cx="12" cy="20" r="11.5" stroke="#C6C6C8"/>
-<path d="M24 20H81" stroke="#C6C6C8"/>
+<svg width="48" height="28" viewBox="0 0 48 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="14" r="6" fill="#4745B7"/>
+<circle cx="12" cy="14" r="11.5" stroke="#C6C6C8"/>
+<path d="M24 14H48" stroke="#C6C6C8"/>
 </svg>

--- a/web/src/templates/page/sections/components/generic/selectorList/component/selector.module.scss
+++ b/web/src/templates/page/sections/components/generic/selectorList/component/selector.module.scss
@@ -23,7 +23,7 @@
                 margin-left: 70px;
             }
             @include min-width($desktopMD) {
-                margin-left: 103px;
+                margin-left: calc(48px + 32px);
             }
         }
         .notSelected {
@@ -36,24 +36,17 @@
             }
         
             @include min-width($desktopMD) {
-                margin-left: 103px;
+                margin-left: calc(48px + 32px);
             }
         }
         & > img {
             display: none;
             @include min-width($desktopSM) {
                 position: absolute;
-                top: 2px;
-                width: 50px;
-                display: block;
-            }
-            @include min-width($desktopMD) {
+                top: 0;
                 left: 0;
-                top: -3px;
-                width: 71px;
-            }
-            @include min-width($desktopXL) {
-                top: -4px;
+                width: 48px;
+                display: block;
             }
         }
     }
@@ -62,7 +55,7 @@
             margin-left: 70px;
         }
         @include min-width($desktopMD) {
-            margin-left: 103px;
+            margin-left: calc(48px + 32px);
         }
         p {
             font-size: 16px;

--- a/web/src/templates/page/sections/components/generic/selectorList/selectorList.module.scss
+++ b/web/src/templates/page/sections/components/generic/selectorList/selectorList.module.scss
@@ -16,7 +16,6 @@
     -ms-overflow-style: none; /* IE and Edge */
     scrollbar-width: none; /* Firefox */
     @include min-width($mobileXL) {
-      margin-left: -4px;
       height: auto;
       @include flex-direction(column);
       overflow-x: hidden;

--- a/web/src/templates/page/sections/components/shared/dynamicSelector/dynamicSelector.module.scss
+++ b/web/src/templates/page/sections/components/shared/dynamicSelector/dynamicSelector.module.scss
@@ -66,8 +66,8 @@
         max-width: 100%;
         @include min-width($mobileXL) {
           @include flex(0, 1, auto);
-          max-width: calc(280px - 16px);
-          min-width: calc(280px - 16px);
+          max-width: 280px;
+          min-width: 280px;
           @include flexbox;
           @include flex-direction(column);
           @include justify-content(space-between);
@@ -75,8 +75,8 @@
           height: 100%;
         }
         @include min-width($desktopMD) {
-          max-width: calc(385px - 16px);
-          min-width: calc(385px - 16px);
+          max-width: 385px;
+          min-width: 385px;
         }
         .selectorImage__desktop {
           display: none;

--- a/web/src/templates/page/sections/components/shared/sideCardsSlider/sideCardsSlider.module.scss
+++ b/web/src/templates/page/sections/components/shared/sideCardsSlider/sideCardsSlider.module.scss
@@ -112,20 +112,30 @@
   @include order(0);
   @include flex(0, 0, 100%);
   @include min-width($mobileXL) {
-    @include flex(0, 0, calc(40% - 30px));
+    @include flex(0, 0, 40%);
+    max-width: 478px;
   }
-  @include min-width($tabletSM) {
-    @include flex(0, 0, calc(40% - 50px));
-  }
-  @include min-width($tabletXL) {
-    @include flex(0, 0, calc(40% - 90px));
-  }
-  @include min-width($desktopSM) {
-    @include flex(0, 0, calc(40% - 133px));
-  }
+  
   &.textAlignRight {
     @include min-width($mobileXL) {
       @include order(1);
+      @include flex(0, 0, calc(40% - 30px));
+      max-width: fit-content;
+      @include min-width($tabletSM) {
+        @include flex(0, 0, calc(40% - 20px));
+      }
+      @include min-width($tabletXL) {
+        @include flex(0, 0, calc(40% - 60px));
+      }
+      @include min-width($desktopSM) {
+        @include flex(0, 0, calc(40% - 100px));
+      }
+      @include min-width($desktopXL) {
+        @include flex(0, 0, calc(40% - 80px));
+      }
+      @include min-width(1560px) {
+        @include flex(0, 0, calc(40% - 60px));
+      }
     }
     &.background {
       &::before {
@@ -150,6 +160,9 @@
         transform: translateY(-50%);
         background: $neutral200;
         z-index: -1;
+      }
+      @include min-width($desktopXL) {
+        width: 85vw;
       }
     }
     &.testimonialCardSlider {


### PR DESCRIPTION
JIRA:

[Fixes: dynamicSelector & sideCardsSlider ](https://gataca.atlassian.net/browse/DEV-4689)


DONE: 
- sideCardsSlider (more info on [issue](https://www.figma.com/design/ZaLWsGc7xbXXeN6ViYjnLu?node-id=8378-78353&m=dev#1103515795)): fixed width of heading when showings cards & credentials, based on textAlignment 

- dynamicCardSelector (more info on [issue]( https://www.figma.com/design/KT2IKvsPLSuX0keXXFCprD?node-id=8343-73881&m=dev#1103543608)): fix of selector image and spaces

RESULT:

- sideCardsSlider https://www.dev.gataca.io/new-page/


https://github.com/user-attachments/assets/b0e2aa83-cae9-4103-aecf-0572e522948b

- dynamicCardSelector https://www.dev.gataca.io/products/gataca-vouch/

![Screenshot 2025-01-24 at 13 54 17](https://github.com/user-attachments/assets/d3ccf3f1-4949-4d3a-86c5-12766eb08024)

