### PR TITLE
DEV-4713: add dark theme option

### DIFF
--- a/admin/config/sync/admin-role.strapi-super-admin.json
+++ b/admin/config/sync/admin-role.strapi-super-admin.json
@@ -3668,7 +3668,8 @@
           "socialMediaButton.buttons",
           "socialMediaButton.brand_buttons",
           "socialMediaButton.button_icons",
-          "rightsReserved"
+          "rightsReserved",
+          "logoDarkTheme"
         ],
         "locales": [
           "en",
@@ -3728,7 +3729,8 @@
           "socialMediaButton.buttons",
           "socialMediaButton.brand_buttons",
           "socialMediaButton.button_icons",
-          "rightsReserved"
+          "rightsReserved",
+          "logoDarkTheme"
         ],
         "locales": [
           "en",
@@ -3766,7 +3768,8 @@
           "socialMediaButton.buttons",
           "socialMediaButton.brand_buttons",
           "socialMediaButton.button_icons",
-          "rightsReserved"
+          "rightsReserved",
+          "logoDarkTheme"
         ],
         "locales": [
           "en",
@@ -4381,7 +4384,8 @@
           "sections",
           "title",
           "slugURL",
-          "subPath"
+          "subPath",
+          "darkTheme"
         ],
         "locales": [
           "en",
@@ -4426,7 +4430,8 @@
           "sections",
           "title",
           "slugURL",
-          "subPath"
+          "subPath",
+          "darkTheme"
         ],
         "locales": [
           "en",
@@ -4449,7 +4454,8 @@
           "sections",
           "title",
           "slugURL",
-          "subPath"
+          "subPath",
+          "darkTheme"
         ],
         "locales": [
           "en",
@@ -4835,7 +4841,8 @@
           "languageButton.size",
           "languageButton.disabled",
           "languageButton.noPaddingText",
-          "languageButton.fullWidth"
+          "languageButton.fullWidth",
+          "logoDarkTheme"
         ],
         "locales": [
           "en",
@@ -4907,7 +4914,8 @@
           "languageButton.size",
           "languageButton.disabled",
           "languageButton.noPaddingText",
-          "languageButton.fullWidth"
+          "languageButton.fullWidth",
+          "logoDarkTheme"
         ],
         "locales": [
           "en",
@@ -4957,7 +4965,8 @@
           "languageButton.size",
           "languageButton.disabled",
           "languageButton.noPaddingText",
-          "languageButton.fullWidth"
+          "languageButton.fullWidth",
+          "logoDarkTheme"
         ],
         "locales": [
           "en",
@@ -5028,7 +5037,8 @@
           "seo.alternate_urls",
           "title",
           "slugURL",
-          "subPath"
+          "subPath",
+          "darkTheme"
         ],
         "locales": [
           "en",
@@ -5073,7 +5083,8 @@
           "seo.alternate_urls",
           "title",
           "slugURL",
-          "subPath"
+          "subPath",
+          "darkTheme"
         ],
         "locales": [
           "en",
@@ -5096,7 +5107,8 @@
           "seo.alternate_urls",
           "title",
           "slugURL",
-          "subPath"
+          "subPath",
+          "darkTheme"
         ],
         "locales": [
           "en",

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_content_types##api##footer.footer.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_content_types##api##footer.footer.json
@@ -147,6 +147,20 @@
           "sortable": true
         }
       },
+      "logoDarkTheme": {
+        "edit": {
+          "label": "logoDarkTheme",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "logoDarkTheme",
+          "searchable": false,
+          "sortable": false
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -193,6 +207,12 @@
             "name": "logo",
             "size": 6
           },
+          {
+            "name": "logoDarkTheme",
+            "size": 6
+          }
+        ],
+        [
           {
             "name": "certificationImage",
             "size": 6

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_content_types##api##home-index.home-index.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_content_types##api##home-index.home-index.json
@@ -90,6 +90,20 @@
           "sortable": true
         }
       },
+      "darkTheme": {
+        "edit": {
+          "label": "darkTheme",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "darkTheme",
+          "searchable": true,
+          "sortable": true
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -133,11 +147,15 @@
             "size": 6
           },
           {
-            "name": "slugURL",
-            "size": 6
+            "name": "darkTheme",
+            "size": 4
           }
         ],
         [
+          {
+            "name": "slugURL",
+            "size": 6
+          },
           {
             "name": "subPath",
             "size": 6

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_content_types##api##menu.menu.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_content_types##api##menu.menu.json
@@ -147,6 +147,20 @@
           "sortable": false
         }
       },
+      "logoDarkTheme": {
+        "edit": {
+          "label": "logoDarkTheme",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "logoDarkTheme",
+          "searchable": false,
+          "sortable": false
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -177,20 +191,20 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "idItem",
-        "logo",
-        "menuDropdown"
-      ],
       "edit": [
         [
           {
             "name": "idItem",
             "size": 6
-          },
+          }
+        ],
+        [
           {
             "name": "logo",
+            "size": 6
+          },
+          {
+            "name": "logoDarkTheme",
             "size": 6
           }
         ],
@@ -234,6 +248,12 @@
             "size": 6
           }
         ]
+      ],
+      "list": [
+        "id",
+        "idItem",
+        "logo",
+        "menuDropdown"
       ]
     }
   },

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_content_types##api##page.page.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_content_types##api##page.page.json
@@ -90,6 +90,20 @@
           "sortable": true
         }
       },
+      "darkTheme": {
+        "edit": {
+          "label": "darkTheme",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "darkTheme",
+          "searchable": true,
+          "sortable": true
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -133,11 +147,15 @@
             "size": 6
           },
           {
-            "name": "slugURL",
-            "size": 6
+            "name": "darkTheme",
+            "size": 4
           }
         ],
         [
+          {
+            "name": "slugURL",
+            "size": 6
+          },
           {
             "name": "subPath",
             "size": 6

--- a/admin/config/sync/core-store.strapi_content_types_schema.json
+++ b/admin/config/sync/core-store.strapi_content_types_schema.json
@@ -5590,6 +5590,21 @@
             }
           }
         },
+        "logoDarkTheme": {
+          "allowedTypes": [
+            "images",
+            "files",
+            "videos",
+            "audios"
+          ],
+          "type": "media",
+          "multiple": false,
+          "pluginOptions": {
+            "i18n": {
+              "localized": true
+            }
+          }
+        },
         "createdAt": {
           "type": "datetime"
         },
@@ -5743,6 +5758,21 @@
           },
           "rightsReserved": {
             "type": "string",
+            "pluginOptions": {
+              "i18n": {
+                "localized": true
+              }
+            }
+          },
+          "logoDarkTheme": {
+            "allowedTypes": [
+              "images",
+              "files",
+              "videos",
+              "audios"
+            ],
+            "type": "media",
+            "multiple": false,
             "pluginOptions": {
               "i18n": {
                 "localized": true
@@ -6660,6 +6690,14 @@
           },
           "type": "string"
         },
+        "darkTheme": {
+          "pluginOptions": {
+            "i18n": {
+              "localized": true
+            }
+          },
+          "type": "boolean"
+        },
         "createdAt": {
           "type": "datetime"
         },
@@ -6798,6 +6836,14 @@
               }
             },
             "type": "string"
+          },
+          "darkTheme": {
+            "pluginOptions": {
+              "i18n": {
+                "localized": true
+              }
+            },
+            "type": "boolean"
           }
         },
         "kind": "singleType"
@@ -7616,6 +7662,21 @@
             }
           }
         },
+        "logoDarkTheme": {
+          "allowedTypes": [
+            "images",
+            "files",
+            "videos",
+            "audios"
+          ],
+          "type": "media",
+          "multiple": false,
+          "pluginOptions": {
+            "i18n": {
+              "localized": true
+            }
+          }
+        },
         "createdAt": {
           "type": "datetime"
         },
@@ -7777,6 +7838,21 @@
             "type": "component",
             "repeatable": false,
             "component": "generic.button",
+            "pluginOptions": {
+              "i18n": {
+                "localized": true
+              }
+            }
+          },
+          "logoDarkTheme": {
+            "allowedTypes": [
+              "images",
+              "files",
+              "videos",
+              "audios"
+            ],
+            "type": "media",
+            "multiple": false,
             "pluginOptions": {
               "i18n": {
                 "localized": true
@@ -7993,6 +8069,15 @@
           "required": true,
           "default": "/"
         },
+        "darkTheme": {
+          "pluginOptions": {
+            "i18n": {
+              "localized": true
+            }
+          },
+          "type": "boolean",
+          "default": false
+        },
         "createdAt": {
           "type": "datetime"
         },
@@ -8134,6 +8219,15 @@
             },
             "required": true,
             "default": "/"
+          },
+          "darkTheme": {
+            "pluginOptions": {
+              "i18n": {
+                "localized": true
+              }
+            },
+            "type": "boolean",
+            "default": false
           }
         },
         "kind": "collectionType"

--- a/admin/src/api/footer/content-types/footer/schema.json
+++ b/admin/src/api/footer/content-types/footer/schema.json
@@ -108,6 +108,21 @@
           "localized": true
         }
       }
+    },
+    "logoDarkTheme": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     }
   }
 }

--- a/admin/src/api/home-index/content-types/home-index/schema.json
+++ b/admin/src/api/home-index/content-types/home-index/schema.json
@@ -88,6 +88,14 @@
         }
       },
       "type": "string"
+    },
+    "darkTheme": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "boolean"
     }
   }
 }

--- a/admin/src/api/menu/content-types/menu/schema.json
+++ b/admin/src/api/menu/content-types/menu/schema.json
@@ -116,6 +116,21 @@
           "localized": true
         }
       }
+    },
+    "logoDarkTheme": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     }
   }
 }

--- a/admin/src/api/page/content-types/page/schema.json
+++ b/admin/src/api/page/content-types/page/schema.json
@@ -91,6 +91,15 @@
       },
       "required": true,
       "default": "/"
+    },
+    "darkTheme": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/web/deployments/deployment-dev.yml
+++ b/web/deployments/deployment-dev.yml
@@ -26,7 +26,7 @@ spec:
             value: "80"
       containers:
         - name: web
-          image: ghcr.io/gataca-io/gataca.io/website:7.1.23-SNAPSHOT
+          image: ghcr.io/gataca-io/gataca.io/website:7.1.24-SNAPSHOT
           imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
     "start": "gatsby develop",
     "typecheck": "tsc --noEmit"
   },
-  "version": "7.1.23",
+  "version": "7.1.24",
   "dependencies": {
     "@bakkenbaeck/gatsby-plugin-rename-routes": "^1.0.0",
     "@types/classnames": "^2.3.1",

--- a/web/src/components/atoms/buttons/purple/purpleButton.module.scss
+++ b/web/src/components/atoms/buttons/purple/purpleButton.module.scss
@@ -2,8 +2,8 @@
 @import "../../../../styles/mixins.scss";
 
 .button {
-    background-color: $primary700;
-    color: $neutral100;
+    background-color: var(--primary700);
+    color: var(--neutral100);
     padding: 12px 24px;
     height: 48px;
     border-radius: 8px;
@@ -13,10 +13,10 @@
     cursor: pointer;
 
     &:hover {
-        background-color: $primary900;
+        background-color: var(--primary900);
     }
     &:focus {
-        box-shadow: inset 0px 0px 0px 2px $primary300;
+        box-shadow: inset 0px 0px 0px 2px var(--primary300);
     }
 
     & > svg {
@@ -25,9 +25,9 @@
 }
 
 .outlinedButton {
-    background-color: $neutral100;
-    border: 1px solid $primary700;
-    color: $neutral1000;
+    background-color: var(--neutral100);
+    border: 1px solid var(--primary700);
+    color: var(--neutral1000);
     padding: 12px 24px;
     height: 48px;
     border-radius: 8px;
@@ -38,10 +38,10 @@
 
      &:hover {
         font-weight: 600;
-        color: $primary700;
+        color: var(--primary700);
     }
     &:focus {
-        box-shadow: inset 0px 0px 0px 2px $primary300;
+        box-shadow: inset 0px 0px 0px 2px var(--primary300);
     }
 
     & > svg {

--- a/web/src/components/atoms/buttons/switchButton/SwicthButton.tsx
+++ b/web/src/components/atoms/buttons/switchButton/SwicthButton.tsx
@@ -34,7 +34,7 @@ const SwitchButton: React.FC<SwitchButtonProps> = React.memo(props => {
         }
         className={styles.periodCheckboxLabel}
       ></label>
-      <span className={`${cx("bodyRegularMD")}`}>{rightLabel}</span>
+      <span className={`${cx("bodyRegularMD neutral1000")}`}>{rightLabel}</span>
     </div>
   )
 })

--- a/web/src/components/atoms/buttons/switchButton/switchButton.module.scss
+++ b/web/src/components/atoms/buttons/switchButton/switchButton.module.scss
@@ -21,8 +21,8 @@
   text-indent: 49px;
   width: 52px;
   height: 26px;
-  background: $neutral100;
-  border: 3px solid $neutral400;
+  background: var(--neutral100);
+  border: 3px solid var(--neutral400);
   display: block;
   border-radius: 90px;
   position: relative;
@@ -37,21 +37,21 @@
   width: 26px;
   min-width: 26px;
   height: 26px;
-  background: $neutral100;
-  border: 3px solid $neutral400;
+  background: var(--neutral100);
+  border: 3px solid var(--neutral400);
   border-radius: 90px;
   transition: 0.3s;
 }
 
 .periodCheckbox:checked + .periodCheckboxLabel {
-  background: $primary700;
-  border: 3px solid $primary700;
+  background: var(--primary700);
+  border: 3px solid var(--primary700);
 }
 
 .periodCheckbox:checked + .periodCheckboxLabel:after {
   width: 18px;
   left: calc(100% - 28px);
-  border: 3px solid $primary700;
+  border: 3px solid var(--primary700);
 }
 
 .periodCheckboxLabel:active:after {

--- a/web/src/components/atoms/buttons/white/whiteButton.module.scss
+++ b/web/src/components/atoms/buttons/white/whiteButton.module.scss
@@ -1,25 +1,25 @@
 @import "../../../../styles/_colors.scss";
 
 .button {
-    background-color: $neutral100;
-    color: $primary1000;
+    background-color: var(--neutral100);
+    color: var(--primary100)0;
     padding: 12px 24px;
     height: 48px;
     border-radius: 8px;
     cursor: pointer;
 
     &:hover {
-        background-color: $primary900;
+        background-color: var(--primary900);
     }
     &:focus {
-        box-shadow: inset 0px 0px 0px 2px $primary300;
+        box-shadow: inset 0px 0px 0px 2px var(--primary300);
     }
 }
 
 .outlinedButton {
     background-color: transparent;
-    border: 1px solid $neutral100;
-    color: $neutral100;
+    border: 1px solid var(--neutral100);
+    color: var(--neutral100);
     padding: 12px 24px;
     height: 48px;
     border-radius: 8px;
@@ -29,6 +29,6 @@
         background-color:rgba(255, 255, 255, 0.2);
     }
     &:focus {
-        box-shadow: inset 0px 0px 0px 2px $primary300;
+        box-shadow: inset 0px 0px 0px 2px var(--primary300);
     }
 }

--- a/web/src/components/atoms/tags/tag.module.scss
+++ b/web/src/components/atoms/tags/tag.module.scss
@@ -2,8 +2,8 @@
 @import "../../../styles/mixins.scss";
 
 .tag {
-    color: $neutral700;
-    background-color: $neutral300;
+    color: var(--neutral700);
+    background-color: var(--neutral300);
     border-radius: 4px;
     padding: 4px 8px;
     height: 16px;

--- a/web/src/components/elements/blogPreview/blogDetailedPreview/blogDetailedPreview.module.scss
+++ b/web/src/components/elements/blogPreview/blogDetailedPreview/blogDetailedPreview.module.scss
@@ -4,10 +4,10 @@
 .blogDetailedPreview {
   @include flexbox();
   @include flex-direction(column);
-  background-color: $neutral100;
+  background-color: var(--neutral100);
   padding: 24px;
   border-radius: 12px;
-  box-shadow: 1px 1px 12px $boxShadowLigh;
+  box-shadow: 1px 1px 12px var(--boxShadowLigh);
 
   & > .imageContainer {
      width: 100%;
@@ -43,7 +43,7 @@
     }
 
     & > .description {
-      color: $grey600;
+      color: var(--neutral400);
       height: 60px;
       display: -webkit-box;
       -webkit-line-clamp: 3;
@@ -52,12 +52,12 @@
       text-overflow: ellipsis;
     }
     & > .date {
-      color: $grey600;
+      color: var(--neutral400);
     }
 
     & > .link {
       margin-top: 22px;
-      color: $primary700;
+      color: var(--primary700);
       cursor: pointer;
       @include flexbox();
       @include align-items(center);

--- a/web/src/components/elements/blogPreview/blogPreview.module.scss
+++ b/web/src/components/elements/blogPreview/blogPreview.module.scss
@@ -6,13 +6,13 @@
   @include flex-direction(column);
   min-width: 0;
   width: calc(100% - 48px);
-  background-color: $neutral100;
+  background-color: var(--neutral100);
 padding: 24px;
   border-radius: 12px;
-  box-shadow: 1px 1px 12px $boxShadowLigh;
+  box-shadow: 1px 1px 12px var(--boxShadowLigh);
   cursor: pointer;
   &:hover {
-    color: $neutral1000
+    color: var(--neutral1000)
   }
   & > .header {
     @include flexbox();
@@ -22,8 +22,8 @@ padding: 24px;
     gap: 20px;
 
     & > .category {
-      color: $neutral700;
-      background-color: $neutral300;
+      color: var(--neutral700);
+      background-color: var(--neutral300);
       border-radius: 4px;
       padding: 4px 8px;
       height: 16px;
@@ -33,7 +33,7 @@ padding: 24px;
 
     & > .readTime {
       margin-left: auto;
-      color: $neutral700
+      color: var(--neutral700)
     }
   }
 

--- a/web/src/components/elements/footer/Footer.tsx
+++ b/web/src/components/elements/footer/Footer.tsx
@@ -50,6 +50,9 @@ const Footer: React.FC = (props: any) => {
           setPage(jsonResponse?.data[0])
       })
   }
+
+  const pageTheme = props?.children[0]?.props?.children[0]?.props?.darkTheme
+
   return (
     <footer className={styles?.footer}>
       <section
@@ -61,9 +64,12 @@ const Footer: React.FC = (props: any) => {
           <div className={styles?.iconsContainer__items}>
             <div className={styles?.logo}>
               <Link to="/">
-                {footerData?.logo?.data?.attributes?.url && (
+                {(footerData?.logo?.data?.attributes?.url ||
+                  footerData?.logoDarkTheme?.data?.attributes?.url) && (
                   <StrapiImage
-                    image={footerData?.logo ? footerData?.logo : null}
+                    image={
+                      pageTheme ? footerData?.logoDarkTheme : footerData?.logo
+                    }
                   />
                 )}
               </Link>

--- a/web/src/components/elements/footer/footer.module.scss
+++ b/web/src/components/elements/footer/footer.module.scss
@@ -4,7 +4,7 @@
 .footer {
   margin: 0 auto;
   padding: 80px 0 0;
-  border-top: 2px solid $neutral300;
+  border-top: 2px solid var(--neutral300);
   .showDesktop {
     display: none;
     @include min-width($mobileXL) {

--- a/web/src/components/elements/header/Header.tsx
+++ b/web/src/components/elements/header/Header.tsx
@@ -53,6 +53,9 @@ const Header: React.FC = (props: any) => {
           setPage(jsonResponse?.data[0])
       })
   }
+
+  const pageTheme = props?.children[0]?.props?.children[0]?.props?.darkTheme
+
   return (
     <>
       {menuData ? (
@@ -61,8 +64,11 @@ const Header: React.FC = (props: any) => {
           onMouseLeave={() => setSubMenuOpened("")}
         >
           <Link className={styles?.header__logo} to="/">
-            {menuData?.logo?.data?.attributes?.url && (
-              <StrapiImage image={menuData?.logo ? menuData?.logo : null} />
+            {(menuData?.logo?.data?.attributes?.url ||
+              menuData?.logoDarkTheme?.data?.attributes?.url) && (
+              <StrapiImage
+                image={pageTheme ? menuData?.logoDarkTheme : menuData?.logo}
+              />
             )}
           </Link>
           <div className={styles?.menuDropdown}>
@@ -116,6 +122,7 @@ const Header: React.FC = (props: any) => {
             pageContext={
               props?.children[0]?.props?.children[0]?.props?.pageContext
             }
+            darkTheme={pageTheme}
           />
         </header>
       ) : (

--- a/web/src/components/elements/header/headerComponents/buttonsHeader/menuOpenMobile/MenuOpenMobile.tsx
+++ b/web/src/components/elements/header/headerComponents/buttonsHeader/menuOpenMobile/MenuOpenMobile.tsx
@@ -16,11 +16,19 @@ export type IMenuDropdownProps = {
   button?: any
   pageContext?: string
   buttonGroup?: ButtonModel
+  darkTheme?: boolean
 }
 
 const MenuOpenMobile: React.FC<IMenuDropdownProps> = props => {
-  const { open, setMenuOpened, menuData, button, pageContext, buttonGroup } =
-    props
+  const {
+    open,
+    setMenuOpened,
+    menuData,
+    button,
+    pageContext,
+    buttonGroup,
+    darkTheme,
+  } = props
   const [subMenuOpenedID, setSubMenuOpened] = React.useState("")
   const refMenuMobile = React.useRef<HTMLDivElement>(null)
   const refMenuMobileHeader = React.useRef<HTMLDivElement>(null)
@@ -73,9 +81,12 @@ const MenuOpenMobile: React.FC<IMenuDropdownProps> = props => {
                 } ${open ? styles.menuContentVisible : ""}`}
               >
                 <Link to="/">
-                  {menuData?.logo?.data?.attributes?.url && (
+                  {(menuData?.logo?.data?.attributes?.url ||
+                    menuData?.logoDarkTheme?.data?.attributes?.url) && (
                     <StrapiImage
-                      image={menuData?.logo ? menuData?.logo : null}
+                      image={
+                        darkTheme ? menuData?.logoDarkTheme : menuData?.logo
+                      }
                     />
                   )}
                 </Link>
@@ -114,7 +125,15 @@ const MenuOpenMobile: React.FC<IMenuDropdownProps> = props => {
             setMenuOpened(!open), setSubMenuOpened("")
           }}
         >
-          <img src={open ? images.closeMenuIcon : images.menuIcon}></img>
+          {darkTheme ? (
+            <img
+              src={
+                open ? images.closeMenuIconDarkTheme : images.menuIconDarkTheme
+              }
+            ></img>
+          ) : (
+            <img src={open ? images.closeMenuIcon : images.menuIcon}></img>
+          )}
         </div>
       </div>
       {open && (

--- a/web/src/components/elements/header/headerComponents/buttonsHeader/menuOpenMobile/menuOpenMobile.module.scss
+++ b/web/src/components/elements/header/headerComponents/buttonsHeader/menuOpenMobile/menuOpenMobile.module.scss
@@ -15,8 +15,8 @@ div.mobileMenu {
     max-width: 100%;
     height: auto;
     min-height: 804px;
-    background-color: $neutral100;
-    box-shadow: 0px 0px 12px $boxShadowLigh;
+    background-color: var(--neutral100);
+    box-shadow: 0px 0px 12px var(--boxShadowLigh);
     border-radius: 6px;
     @include flexbox();
     @include flex-direction(column);
@@ -41,7 +41,7 @@ div.mobileMenu {
     min-height: 40px;
     &.opened {
       padding: 16px 16px;
-      border-bottom: 2px solid $neutral300;
+      border-bottom: 2px solid var(--neutral300);
       @include justify-content(space-between);
     }
   }
@@ -56,7 +56,7 @@ div.mobileMenu {
   .buttonsContainer {
     @include flexbox();
     padding: 20px;
-    border-top: 2px solid $neutral300;
+    border-top: 2px solid var(--neutral300);
   }
   .backLink {
     @include flexbox();
@@ -115,6 +115,7 @@ div.mobileMenu {
 
 .menuIconContainer {
   margin-left: auto;  
+  cursor: pointer;
 }
 
 /* Animation */

--- a/web/src/components/elements/header/headerComponents/headerSkeleton/headerSkeleton.module.scss
+++ b/web/src/components/elements/header/headerComponents/headerSkeleton/headerSkeleton.module.scss
@@ -16,7 +16,7 @@
 }
 
 .skeleton {
-    background: $skeletonBG;
+    background: var(--skeletonBG);
     overflow: hidden;
     width: 200px;
     height: 48px;
@@ -51,7 +51,7 @@
     display: block;
     width: 200px;
     height: 48px;
-    background: linear-gradient(90deg, rgba(255, 255, 255, 0), $neutral100, rgba(255, 255, 255, 0));
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0), var(--neutral100), rgba(255, 255, 255, 0));
     content: "";
     animation: skeleton-animation 2s infinite;
 }

--- a/web/src/components/elements/header/headerComponents/menuSubOption/menuSubOption.module.scss
+++ b/web/src/components/elements/header/headerComponents/menuSubOption/menuSubOption.module.scss
@@ -11,7 +11,7 @@
   height: 100%;
   max-height: 724px;
   z-index: 9999;
-  background-color: $neutral100;
+  background-color: var(--neutral100);
   transform: translateX(100%);
   @include min-width(1200.01px) {
     top: 30px;
@@ -57,7 +57,7 @@
         padding: 0;
       }
       &:first-child {
-        border-top: 2px solid $neutral300;
+        border-top: 2px solid var(--neutral300);
         padding: 28px 20px 0;
         @include min-width(1200.01px) {
           border: none;
@@ -65,7 +65,7 @@
         }
       }
       &:nth-child(2) {
-        border-top: 2px solid $neutral300;
+        border-top: 2px solid var(--neutral300);
         padding-top: 28px;
         @include min-width(1200.01px) {
           border: none;

--- a/web/src/components/elements/logosSlider/logosSlider.module.scss
+++ b/web/src/components/elements/logosSlider/logosSlider.module.scss
@@ -2,7 +2,7 @@
 @import "../../../styles/mixins";
 
 .logosSlider {
-  background-color: $neutral200;
+  background-color: var(--neutral200);
   .clientsLogo {
     max-width: 100vw;
     padding: 55px 0;

--- a/web/src/components/elements/markDownContent/markDownContent.module.scss
+++ b/web/src/components/elements/markDownContent/markDownContent.module.scss
@@ -10,11 +10,11 @@
     font-weight: 400;
     line-height: 24px;
     text-decoration: none;
-    color: $neutral700;
+    color: var(--neutral700);
   }
 
   & > a, p > a, span > a, li > a {
-    color: $primary700;
+    color: var(--primary700);
     text-decoration: underline;
     cursor: pointer;
     font-family: $base;
@@ -31,7 +31,7 @@
         position: absolute;
         width: 6px;
         height: 6px;
-        background-color: $neutral700;
+        background-color: var(--neutral700);
         border-radius: 5px;
         top: 9px;
         left: -15px;
@@ -114,15 +114,15 @@
     & > table {
       margin: 0 auto 20px;
       border-radius: 12px;
-      border: 1px solid $neutral300;
-      background-color: $neutral100;
+      border: 1px solid var(--neutral300);
+      background-color: var(--neutral100);
       > * {
         font-family: $base;
         font-size: 18px;
         font-weight: 400;
         line-height: 24px;
         text-decoration: none;
-        color: $neutral700;
+        color: var(--neutral700);
       }
     }
     thead {
@@ -133,18 +133,18 @@
         font-weight: 700;
         line-height: 28px;
         text-decoration: none;
-        color: $neutral1000;
+        color: var(--neutral1000);
         &:not(:first-child){  
-          border-left: 1px solid $neutral300;
+          border-left: 1px solid var(--neutral300);
         }
       }
     }
     tbody {
       td{
-        border-top: 1px solid $neutral300;
+        border-top: 1px solid var(--neutral300);
         padding: 12px;
         &:not(:first-child) {
-          border-left: 1px solid $neutral300;
+          border-left: 1px solid var(--neutral300);
         }
       }
     }

--- a/web/src/components/elements/panels/checksGreyPanel/checksGreyPanel.module.scss
+++ b/web/src/components/elements/panels/checksGreyPanel/checksGreyPanel.module.scss
@@ -3,7 +3,7 @@
 
 .checksGreyPanel__container {
   position: relative;
-  background-color: $neutral200;
+  background-color: var(--neutral200);
   border-radius: 20px;
   padding: 40px;
   max-width: 1104px;
@@ -43,7 +43,7 @@
     }
   }
   .bullet__description {
-    color: $neutral700;
+    color: var(--neutral700);
     margin-bottom: 32px;
   }
   .checksGreyPanel__rightSide__bullets__container {
@@ -58,7 +58,7 @@
       margin-right: 12px;
     }
     .bullets__container__description {
-      color: $neutral700;
+      color: var(--neutral700);
     }
   }
 }

--- a/web/src/components/elements/panels/checksGreyPanelTwoColumns/checksGreyPanelTwoColumns.module.scss
+++ b/web/src/components/elements/panels/checksGreyPanelTwoColumns/checksGreyPanelTwoColumns.module.scss
@@ -3,7 +3,7 @@
 
 .checksGreyPanelTwoColumns {
   position: relative;
-  background-color: $neutral200;
+  background-color: var(--neutral200);
   border-radius: 20px;
   padding: 72px 40px;
   overflow-x: hidden;
@@ -147,6 +147,6 @@
   }
 
   .bullet__description {
-    color: $neutral700;
+    color: var(--neutral700);
   }
 }

--- a/web/src/components/elements/skeletons/blogPreviewSkeleton/blogPreviewSkeleton.module.scss
+++ b/web/src/components/elements/skeletons/blogPreviewSkeleton/blogPreviewSkeleton.module.scss
@@ -7,11 +7,11 @@
     overflow: hidden;
     margin: var(--ga-space-min) 0 15px;
     border-radius: 10px;
-    background: $skeletonBG;
+    background: var(--skeletonBG);
     width: 303px;
     height: 393px;
     border-radius: 12px;
-    box-shadow: 1px 1px 12px $boxShadowLigh;
+    box-shadow: 1px 1px 12px var(--boxShadowLigh);
   
   @include min-width($mobileXL) {
     width: 373px;
@@ -105,7 +105,7 @@
     width: 128px;
 
       height: 393px;
-    background: linear-gradient(90deg, rgba(255, 255, 255, 0), $neutral100, rgba(255, 255, 255, 0));
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0), var(--neutral100), rgba(255, 255, 255, 0));
     content: "";
     animation: skeleton-animation 2s infinite;
      @include min-width($mobileXL) {

--- a/web/src/components/elements/tooltip/hoverTooltip/HoverTooltip.tsx
+++ b/web/src/components/elements/tooltip/hoverTooltip/HoverTooltip.tsx
@@ -17,7 +17,11 @@ const HoverTooltip: React.FC<IHoverTooltipProps> = props => {
       }`}
     >
       <img src={images.infoIcon} />
-      <p className={`${styles?.hoverTooltipText} ${cx("bodyRegularXS")}`}>
+      <p
+        className={`${styles?.hoverTooltipText} ${cx(
+          "bodyRegularXS neutral1000"
+        )}`}
+      >
         {label}
       </p>
     </span>

--- a/web/src/components/elements/tooltip/hoverTooltip/hoverTooltip.module.scss
+++ b/web/src/components/elements/tooltip/hoverTooltip/hoverTooltip.module.scss
@@ -5,8 +5,8 @@
 .hoverTooltip .hoverTooltipText {
   visibility: hidden;
   width: 200px;
-  background-color: $neutral1000;
-  color: $neutral100;
+  background-color: var(--neutral1000);
+  color: var(--neutral100);
   text-align: left;
   border-radius: 6px;
   padding: 8px;
@@ -24,7 +24,7 @@
 
 .hoverTooltipText {
   margin-top: 5px;
-  color: $neutral100;
+  color: var(--neutral100);
 }
 
 .hoverTooltipText::before {
@@ -38,5 +38,5 @@
   position: absolute;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
-  border-bottom: 7px solid $neutral1000;
+  border-bottom: 7px solid var(--neutral1000);
 }

--- a/web/src/components/templates/cards/cardList/cardList.module.scss
+++ b/web/src/components/templates/cards/cardList/cardList.module.scss
@@ -5,8 +5,8 @@
 .card__list {
   @include flex(0, 0, calc(100% - 64px));
   min-height: 236px;
-  background: $neutral100;
-  box-shadow: 0px 0px 12px $boxShadowLigh;
+  background: var(--neutral100);
+  box-shadow: 0px 0px 12px var(--boxShadowLigh);
   border-radius: 20px;
   padding: 32px;
   @include min-width($mobileXL) {
@@ -38,6 +38,6 @@
     font-weight: 400;
     line-height: 20px;
     text-decoration: none;
-    color: $neutral700
+    color: var(--neutral700)
   }
 }

--- a/web/src/components/templates/listInfo/listInfo.module.scss
+++ b/web/src/components/templates/listInfo/listInfo.module.scss
@@ -27,9 +27,9 @@
       }
 
       &.selected {
-        color: $primary700;
+        color: var(--primary700);
         margin-bottom: 20px;
-        border: 1px solid $primary700;
+        border: 1px solid var(--primary700);
         border-radius: 8px;
         padding: 8px;
       }

--- a/web/src/components/templates/listInfoItems/listInfoItems.module.scss
+++ b/web/src/components/templates/listInfoItems/listInfoItems.module.scss
@@ -3,7 +3,7 @@
 @import "../../../styles/_types.scss";
 
 .container {
-  background: $neutral100;
+  background: var(--neutral100);
   box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.12);
   border-radius: 8px;
   padding: 16px;
@@ -12,7 +12,7 @@
     margin-bottom: 24px;
   }
   & > .description {    
-    color: $neutral700;
+    color: var(--neutral700);
   }
 }
 

--- a/web/src/components/templates/mainLayout/MainLayout.jsx
+++ b/web/src/components/templates/mainLayout/MainLayout.jsx
@@ -5,7 +5,7 @@ import Footer from "../../elements/footer/Footer"
 import { SeoHelmet } from "../../elements/seo/SeoHelmet"
 
 const Layout = props => {
-  const { seoData } = props
+  const { seoData, className } = props
 
   React.useEffect(() => {
         const listenConsentEvents = () => {
@@ -126,20 +126,22 @@ const Layout = props => {
 
   return (
     <>
-      <Header >{props.children} </Header>
-      {seoData && (
-        <SeoHelmet
-          metaTitle={seoData?.metaTitle}
-          metaDescription={seoData?.metaDescription}
-          rrssImg={seoData?.rrssImg}
-          keywords={seoData?.keywords}
-          id={seoData?.id}
-          canonicalURL={seoData?.canonicalURL}
-          alternateURL={seoData?.alternate_urls}
-        />
-      )}
-      <main className={styles?.mainLayout}>{props.children}</main>
-      <Footer>{props.children} </Footer>
+      <div id='mainLayout__container' className={className}>
+        <Header>{props.children} </Header>
+        {seoData && (
+          <SeoHelmet
+            metaTitle={seoData?.metaTitle}
+            metaDescription={seoData?.metaDescription}
+            rrssImg={seoData?.rrssImg}
+            keywords={seoData?.keywords}
+            id={seoData?.id}
+            canonicalURL={seoData?.canonicalURL}
+            alternateURL={seoData?.alternate_urls}
+          />
+        )}
+        <main className={styles?.main}>{props.children}</main>
+        <Footer>{props.children} </Footer>
+      </div>
     </>
   )
 }

--- a/web/src/components/templates/mainLayout/mainLayout.module.scss
+++ b/web/src/components/templates/mainLayout/mainLayout.module.scss
@@ -1,4 +1,4 @@
-.mainLayout {
+.main {
   padding: 32px 0 0;
   height: 100%;
 }

--- a/web/src/components/templates/mainLayout/mainLayout.module.scss.d.ts
+++ b/web/src/components/templates/mainLayout/mainLayout.module.scss.d.ts
@@ -1,1 +1,1 @@
-export const mainLayout: string
+export const main: string

--- a/web/src/components/templates/sections/preFooterCTA/preFooterCTA.module.scss
+++ b/web/src/components/templates/sections/preFooterCTA/preFooterCTA.module.scss
@@ -3,7 +3,7 @@
 
 .preFooterCTA {
   padding: 80px 20px 70px;
-  background-color: $neutral1000;
+  background-color: var(--neutral1000);
   @include flexbox();
   @include flex-direction(column);
   @include justify-content(center);
@@ -15,7 +15,7 @@
 
   & > p, h6 {
     text-align: center;
-    color: $neutral100;
+    color: var(--neutral100);
     max-width: 980px;
   }
 
@@ -30,12 +30,12 @@
     }
 
     & > a {
-      background-color: $primary700;
+      background-color: var(--primary700);
       border-radius: 8px;
       height: 52px;
       min-width: 178px;
       &:hover {
-         background-color: $primary900;
+         background-color: var(--primary900);
       }
     }
     & > button {

--- a/web/src/components/templates/tableOfContent/elements/tableOfContentContainer/tableOfContentContainer.module.scss
+++ b/web/src/components/templates/tableOfContent/elements/tableOfContentContainer/tableOfContentContainer.module.scss
@@ -13,7 +13,7 @@
   }
   > div {
     padding: 12px 20px;
-    background-color: $neutral200;
+    background-color: var(--neutral200);
     margin-top: -46px;
     @include min-width($tabletMD) {
       border-radius: 12px;
@@ -28,7 +28,7 @@
       @include align-items(center);
       width: 100%;
       span {
-        color: $neutral1000;
+        color: var(--neutral1000);
         font-family: "Poppins";
         font-size: 18px;
         font-weight: 700;

--- a/web/src/images/icons/gat-icon-close-dark-theme.svg
+++ b/web/src/images/icons/gat-icon-close-dark-theme.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 6L6 18" stroke="#A9A9AC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 6L18 18" stroke="#A9A9AC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/web/src/images/icons/gat-icon-menu-dark.svg
+++ b/web/src/images/icons/gat-icon-menu-dark.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3 12H21" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3 6H21" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3 18H21" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/web/src/images/images.tsx
+++ b/web/src/images/images.tsx
@@ -140,7 +140,9 @@ import thumbsUp from "./images3d/tumbsup.png"
 import cloudShieldIcon from "./icons/cloud-shield.svg"
 import usersIcon from "./icons/users.svg"
 import menuIcon from "./icons/gat-icon-menu.svg"
+import menuIconDarkTheme from "./icons/gat-icon-menu-dark.svg"
 import closeMenuIcon from "./icons/gat-icon-close.svg"
+import closeMenuIconDarkTheme from "./icons/gat-icon-close-dark-theme.svg"
 import chevronLeftIcon from "./icons/chevronLeft.svg"
 import ISO27001Certification from "./logos/iso-27001-certification.svg"
 import ISO27001Logo from "./logos/iso27001.svg"
@@ -309,7 +311,9 @@ export const images = {
   cloudShieldIcon: cloudShieldIcon,
   usersIcon: usersIcon,
   menuIcon: menuIcon,
+  menuIconDarkTheme: menuIconDarkTheme,
   closeMenuIcon: closeMenuIcon,
+  closeMenuIconDarkTheme: closeMenuIconDarkTheme,
   chevronLeftIcon: chevronLeftIcon,
   ISO27001Certification: ISO27001Certification,
   ISO27001Logo: ISO27001Logo,

--- a/web/src/interfaces/interfaces.tsx
+++ b/web/src/interfaces/interfaces.tsx
@@ -131,6 +131,7 @@ export interface PageModel extends PagePreviewModel {
   locale?: string
   localizations?: LocalizationsModel
   pageContext?: string
+  darkTheme: boolean
 }
 
 export interface InsideSectionsModel {
@@ -540,6 +541,7 @@ export interface MenuModel {
     idItem?: string
     className?: string
     logo?: any
+    logoDarkTheme?: any
     menuDropdown?: any
     button?: any
     backButtonMobile?: ButtonModel
@@ -555,6 +557,7 @@ export interface FooterModel {
     idItem?: string
     className?: string
     logo?: any
+    logoDarkTheme?: any
     certificationImage?: any
     linksList?: any
     languageButton?: ButtonModel

--- a/web/src/pages/company/aboutUs/sections/firstSection/firstSection.module.scss
+++ b/web/src/pages/company/aboutUs/sections/firstSection/firstSection.module.scss
@@ -27,7 +27,7 @@
       margin-left: auto;
       margin-right: auto;
       span {
-        color: $primary700;
+        color: var(--primary700);
         font-family: $custom;
       }
     }

--- a/web/src/pages/company/aboutUs/sections/fourthSection/fourthSection.module.scss
+++ b/web/src/pages/company/aboutUs/sections/fourthSection/fourthSection.module.scss
@@ -57,7 +57,7 @@
           margin: 0 auto;
           .leftColumn {
             .name {
-              color: $primary700;
+              color: var(--primary700);
               text-align: left;
             }
             .title {

--- a/web/src/pages/company/aboutUs/sections/secondSection/secondSection.module.scss
+++ b/web/src/pages/company/aboutUs/sections/secondSection/secondSection.module.scss
@@ -9,7 +9,7 @@
   }
   .secondSection__container {
     text-align: center;
-    background-color: $neutral200;
+    background-color: var(--neutral200);
     padding: 80px 20px;
     @include min-width($mobileXL) {
       padding: 80px;
@@ -19,7 +19,7 @@
       margin-left: auto;
       margin-right: auto;
       span {
-        color: $primary700;
+        color: var(--primary700);
         font-family: $custom;
       }
     }

--- a/web/src/pages/company/aboutUs/sections/sixthSection/sixthSection.module.scss
+++ b/web/src/pages/company/aboutUs/sections/sixthSection/sixthSection.module.scss
@@ -4,7 +4,7 @@
 .sixthSection {
   .sixthSection__container {
     text-align: center;
-    background-color: $neutral200;
+    background-color: var(--neutral200);
     padding: 40px 20px;
     @include min-width($mobileXL) {
       padding: 40px;

--- a/web/src/pages/company/aboutUs/sections/thirdSection/thirdSection.module.scss
+++ b/web/src/pages/company/aboutUs/sections/thirdSection/thirdSection.module.scss
@@ -43,7 +43,7 @@
           @include justify-content(space-between);
         }
         .number {
-          color: $primary200;
+          color: var(--primary200);
         }
         .list {
           margin-bottom: 32px;

--- a/web/src/pages/company/becomeAPartner/sections/fifthSection/components/formSkeleton.module.scss
+++ b/web/src/pages/company/becomeAPartner/sections/fifthSection/components/formSkeleton.module.scss
@@ -33,7 +33,7 @@
   }
   .skeleton {
     width: 100%;
-    background: $skeletonBG;
+    background: var(--skeletonBG);
     height: 64px;
     border-radius: 8px;
     margin-bottom: 18px;
@@ -148,7 +148,7 @@
   display: block;
   width: 128px;
   height: 871px;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0), $neutral100, rgba(255, 255, 255, 0));
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0), var(--neutral100), rgba(255, 255, 255, 0));
   content: "";
   animation: skeleton-animation 2s infinite;
   @include min-width($mobileXL) {

--- a/web/src/pages/company/becomeAPartner/sections/fifthSection/fifthSection.module.scss
+++ b/web/src/pages/company/becomeAPartner/sections/fifthSection/fifthSection.module.scss
@@ -49,7 +49,7 @@
       position: absolute;
       width: 2000px;
       height: 937px;
-      background: $neutral1000;
+      background: var(--neutral1000);
       border-radius: 40px 0px 0px 40px;
       z-index: -1;
       top: 205px;
@@ -66,10 +66,10 @@
     }
 
     .form_container {
-      background-color: $neutral100;
+      background-color: var(--neutral100);
       padding: 40px;
       border-radius: 12px;
-      filter: drop-shadow(0px 0px 10px $boxShadowLigh);
+      filter: drop-shadow(0px 0px 10px var(--boxShadowLigh));
       max-width: calc(591px - 80px);
       margin: 0 auto;
       min-height: 900px;

--- a/web/src/pages/company/becomeAPartner/sections/firstSection/firstSection.module.scss
+++ b/web/src/pages/company/becomeAPartner/sections/firstSection/firstSection.module.scss
@@ -52,7 +52,7 @@
           height: 240px;
           bottom: 0px;
           left: 100px;
-          background: $neutral200;
+          background: var(--neutral200);
           border-radius: 40px 0px 0px 40px;
           z-index: -1;
           @include min-width($mobileMD) {

--- a/web/src/pages/company/becomeAPartner/sections/fourthSection/fourthSection.module.scss
+++ b/web/src/pages/company/becomeAPartner/sections/fourthSection/fourthSection.module.scss
@@ -45,7 +45,7 @@
       margin-bottom: 0;
       @include min-width($mobileXL) { 
         @include flex(0, 0, calc((100%/2) - 72px));
-        box-shadow: 0px 0px 12px $boxShadowLigh;
+        box-shadow: 0px 0px 12px var(--boxShadowLigh);
       }
       @include min-width($tabletXL) {
         @include flex(0, 0, calc((100%/4) - 72px));

--- a/web/src/pages/company/becomeAPartner/sections/secondSection/secondSection.module.scss
+++ b/web/src/pages/company/becomeAPartner/sections/secondSection/secondSection.module.scss
@@ -18,12 +18,12 @@
       margin-bottom: 80px;
     }
     a {
-      color: $primary700;
+      color: var(--primary700);
       font-family: $base;
     }
     .content__cards {
-      background: $neutral100;
-      box-shadow: 0px 0px 12px $boxShadowLigh;
+      background: var(--neutral100);
+      box-shadow: 0px 0px 12px var(--boxShadowLigh);
       border-radius: 20px;
       max-width: 277px;
       gap: 52px;
@@ -53,7 +53,7 @@
       }
     }
     .content__footer {
-      background: $neutral200;
+      background: var(--neutral200);
       border-radius: 20px;
       padding: 120px 20px 60px;
       margin-top: -60px;

--- a/web/src/pages/company/becomeAPartner/sections/thirdSection/thirdSection.module.scss
+++ b/web/src/pages/company/becomeAPartner/sections/thirdSection/thirdSection.module.scss
@@ -48,7 +48,7 @@
           gap: 32px
         }
         .number {
-          color: $primary200;
+          color: var(--primary200);
         }
         .list {
           margin-bottom: 32px;

--- a/web/src/pages/company/careers/sections/thirdSection/components/formSkeleton.module.scss
+++ b/web/src/pages/company/careers/sections/thirdSection/components/formSkeleton.module.scss
@@ -31,7 +31,7 @@
   }
   .skeleton {
     width: 100%;
-    background: $skeletonBG;
+    background: var(--skeletonBG);
     height: 64px;
     border-radius: 8px;
     margin-bottom: 18px;
@@ -142,7 +142,7 @@
   display: block;
   width: 128px;
   height: 871px;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0), $neutral100, rgba(255, 255, 255, 0));
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0), var(--neutral100), rgba(255, 255, 255, 0));
   content: "";
   animation: skeleton-animation 2s infinite;
   @include min-width($mobileXL) {

--- a/web/src/pages/company/careers/sections/thirdSection/thirdSection.module.scss
+++ b/web/src/pages/company/careers/sections/thirdSection/thirdSection.module.scss
@@ -54,7 +54,7 @@
       position: absolute;
       width: 2000px;
       height: 820px;
-      background: $neutral200;
+      background: var(--neutral200);
       border-radius: 40px 0px 0px 40px;
       z-index: -1;
       top: 92px;
@@ -70,10 +70,10 @@
     }
 
     .form_container {
-      background-color: $neutral100;
+      background-color: var(--neutral100);
       padding: 40px;
       border-radius: 12px;
-      filter: drop-shadow(0px 0px 10px $boxShadowLigh);
+      filter: drop-shadow(0px 0px 10px var(--boxShadowLigh));
       max-width: 410px;
       margin: 0 auto;
       min-height: 685px;

--- a/web/src/pages/company/contactUs/sections/firstSection/components/formSkeleton.module.scss
+++ b/web/src/pages/company/contactUs/sections/firstSection/components/formSkeleton.module.scss
@@ -33,7 +33,7 @@
   }
   .skeleton {
     width: 100%;
-    background: $skeletonBG;
+    background: var(--skeletonBG);
     height: 64px;
     border-radius: 8px;
     margin-bottom: 18px;
@@ -148,7 +148,7 @@
   display: block;
   width: 128px;
   height: 871px;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0), $neutral100, rgba(255, 255, 255, 0));
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0), var(--neutral100), rgba(255, 255, 255, 0));
   content: "";
   animation: skeleton-animation 2s infinite;
   @include min-width($mobileXL) {

--- a/web/src/pages/company/contactUs/sections/firstSection/firstSection.module.scss
+++ b/web/src/pages/company/contactUs/sections/firstSection/firstSection.module.scss
@@ -56,11 +56,11 @@
   }
 
   .form_container {
-    background-color: $neutral100;
+    background-color: var(--neutral100);
     padding: 40px;
     margin-top: calc(80px - 24px);
     border-radius: 12px;
-    filter: drop-shadow(0px 0px 10px $boxShadowLigh);
+    filter: drop-shadow(0px 0px 10px var(--boxShadowLigh));
     @include min-width($tabletXL) {
       margin-top: 0;
     }

--- a/web/src/pages/company/contactUs/sections/secondSection/secondSection.module.scss
+++ b/web/src/pages/company/contactUs/sections/secondSection/secondSection.module.scss
@@ -21,7 +21,7 @@
       height: 575px;
       right: -20px;
       top: 0;
-      background: $neutral200;
+      background: var(--neutral200);
       border-radius: 40px 0px 0px 40px;
       z-index: -1;
       @include min-width($mobileXL) {
@@ -105,7 +105,7 @@
           @include flex(0, 0, calc(66% - 32px));
         }
         a {
-          color: $primary700;
+          color: var(--primary700);
           &:hover {
             text-decoration: underline;
           }

--- a/web/src/pages/cookiePolicyOld/index.module.scss
+++ b/web/src/pages/cookiePolicyOld/index.module.scss
@@ -46,7 +46,7 @@
   }
 
   p {
-    color: $neutral700;
+    color: var(--neutral700);
   }
 
   .sectionMain {
@@ -70,7 +70,7 @@
       text-decoration: none;
 
       &.mainListTitle {
-        color: $neutral1000;
+        color: var(--neutral1000);
       }
     }
 
@@ -117,7 +117,7 @@
       }
 
       a {
-        color: $primary700;
+        color: var(--primary700);
         font-family: $base;
       }
 
@@ -132,7 +132,7 @@
             position: absolute;
             width: 5px;
             height: 5px;
-            background-color: $neutral700;
+            background-color: var(--neutral700);
             border-radius: 5px;
             top: 10px;
             left: -15px;

--- a/web/src/pages/cookiePolicyOld/table/table.module.scss
+++ b/web/src/pages/cookiePolicyOld/table/table.module.scss
@@ -22,8 +22,8 @@
       }
 
       & > th {
-        background-color: $neutral100;
-        border: 1px solid $neutral300;
+        background-color: var(--neutral100);
+        border: 1px solid var(--neutral300);
         padding: 20px 12px;
         line-height: 16px;
         font-family: "Poppins";
@@ -31,7 +31,7 @@
         font-weight: 700;
         font-size: 20px;
         line-height: 28px;
-        color: $neutral1000;
+        color: var(--neutral1000);
         text-align: left;
       }
     }
@@ -52,8 +52,8 @@
 
     & > tr {
       & > td {
-        background-color: $neutral100;
-        border: 1px solid $neutral300;
+        background-color: var(--neutral100);
+        border: 1px solid var(--neutral300);
         padding: 12px;
         font-family: "Poppins";
         font-style: normal;
@@ -61,7 +61,7 @@
         font-size: 18px;
         line-height: 24px;
         text-align: left;
-        color: $neutral700;
+        color: var(--neutral700);
 
         & > ul > li {
           margin-left: 15px !important;
@@ -91,7 +91,7 @@
     font-weight: 700;
     font-size: 20px;
     line-height: 28px;
-    color: $neutral1000;
+    color: var(--neutral1000);
     width: fit-content;
     display: block;
     margin-bottom: 12px;

--- a/web/src/pages/home/components/listItems/listItems.module.scss
+++ b/web/src/pages/home/components/listItems/listItems.module.scss
@@ -15,7 +15,7 @@
     position: relative;
     @include flexbox();
     .title {
-      color: $primary700;
+      color: var(--primary700);
       @include min-width($desktopSM) {
         margin-left: 70px;
       }
@@ -24,7 +24,7 @@
       }
     }
     .notSelected {
-      color: $neutral1000;
+      color: var(--neutral1000);
       cursor: pointer;
       margin-bottom: 20px;
       font-family: $base;

--- a/web/src/pages/home/sections/fifthSection/fifthSection.module.scss
+++ b/web/src/pages/home/sections/fifthSection/fifthSection.module.scss
@@ -15,7 +15,7 @@
     max-width: 778px;
     margin: 0 auto 80px;
     .description span{
-      color: $primary700;
+      color: var(--primary700);
       font-family: $custom;
     }
   }
@@ -32,7 +32,7 @@
     }
     video {
       max-width: 100%;
-      box-shadow: 0px 0px 16px 0px $boxShadowLigh;
+      box-shadow: 0px 0px 16px 0px var(--boxShadowLigh);
       @include min-width($desktopXL) {
         max-width: 982px;
       }
@@ -45,7 +45,7 @@
       height: 70%;
       bottom: -20px;
       left: -5px;
-      background: $neutral1000;
+      background: var(--neutral1000);
       border-radius: 11px;
       z-index: -1;
       padding: 0 5px;

--- a/web/src/pages/home/sections/firstSection/firstSection.module.scss
+++ b/web/src/pages/home/sections/firstSection/firstSection.module.scss
@@ -46,7 +46,7 @@
   }
 
   & > p {
-    color: $neutral700;
+    color: var(--neutral700);
   }
 
   & > .buttons_container {

--- a/web/src/pages/home/sections/fourthSection/fourthSection.module.scss
+++ b/web/src/pages/home/sections/fourthSection/fourthSection.module.scss
@@ -65,7 +65,7 @@
       @include justify-content(space-between);
       margin-top: -70px;
       height: 149px;
-      background-color: $neutral200;
+      background-color: var(--neutral200);
       padding: 127px 18px 16px;
     }
 
@@ -80,13 +80,13 @@
       height: fit-content;
       min-width: 220px;
       max-width: 220px;
-      background-color: $neutral100;
+      background-color: var(--neutral100);
       padding: 40px;
       border-radius: 20px;
       text-align: left;
       overflow: hidden;
       cursor: pointer;
-      box-shadow: 0px 0px 10px $boxShadowLigh;
+      box-shadow: 0px 0px 10px var(--boxShadowLigh);
       @include flexbox();
       @include flex-direction(column);
       @include align-items(flex-start);
@@ -113,7 +113,7 @@
       }
 
       & > .advantage__description {
-        color: $neutral700;
+        color: var(--neutral700);
       }
     }
   }

--- a/web/src/pages/home/sections/seventhSection/seventhSection.module.scss
+++ b/web/src/pages/home/sections/seventhSection/seventhSection.module.scss
@@ -51,7 +51,7 @@
 
         .seventhSection__leftSide__feedbackBullet {
           position: relative;
-          background-color: $primary200;
+          background-color: var(--primary200);
 
           width: calc(100% - 80px);
           padding: 40px;
@@ -105,7 +105,7 @@
             height: calc(100% + 176px);
             right: 0px;
             right: -40px;
-            background: $neutral200;
+            background: var(--neutral200);
             border-radius: 40px 0px 0px 40px;
             z-index: -1;
             top: 50%;
@@ -144,7 +144,7 @@
           width: 75vw;
           height: 591px;
           right: -40px;
-          background: $neutral200;
+          background: var(--neutral200);
           border-radius: 40px 0px 0px 40px;
           z-index: -1;
           display: none;

--- a/web/src/pages/index.tsx
+++ b/web/src/pages/index.tsx
@@ -3,6 +3,7 @@ import Layout from "../components/templates/mainLayout/MainLayout"
 import Highlight from "../templates/page/sections/components/shared/Highlight/Highlight"
 import AllSectionsTemplate from "../templates/page/sections/AllSectionsTemplate"
 import PageSkeleton from "../templates/page/components/introBlogSkeleton/PageSkeleton"
+import * as styles from "../templates/page/pageTemplate.module.scss"
 
 const IndexPage: React.FC = (props: any) => {
   const [homeStrapiData, setHomeStrapiData] = React.useState<any | undefined>()
@@ -21,8 +22,13 @@ const IndexPage: React.FC = (props: any) => {
       })
   }
 
+  const pageTheme = homeData?.darkTheme
+
   return (
-    <Layout seoData={homeData?.seo}>
+    <Layout
+      className={pageTheme ? styles?.dark__theme : styles?.light__theme}
+      seoData={homeData?.seo}
+    >
       <>
         {homeData ? (
           <AllSectionsTemplate

--- a/web/src/pages/legalNoticeOld/index.module.scss
+++ b/web/src/pages/legalNoticeOld/index.module.scss
@@ -46,7 +46,7 @@
   }
 
   p {
-    color: $neutral700;
+    color: var(--neutral700);
   }
 
   .sectionMain {
@@ -70,7 +70,7 @@
       text-decoration: none;
 
       &.mainListTitle {
-        color: $neutral1000;
+        color: var(--neutral1000);
       }
     }
 
@@ -117,7 +117,7 @@
       }
 
       a {
-        color: $primary700;
+        color: var(--primary700);
         font-family: $base;
       }
 
@@ -132,7 +132,7 @@
             position: absolute;
             width: 5px;
             height: 5px;
-            background-color: $neutral700;
+            background-color: var(--neutral700);
             border-radius: 5px;
             top: 10px;
             left: -15px;

--- a/web/src/pages/legalNoticeOld/table/table.module.scss
+++ b/web/src/pages/legalNoticeOld/table/table.module.scss
@@ -22,8 +22,8 @@
       }
 
       & > th {
-        background-color: $neutral100;
-        border: 1px solid $neutral300;
+        background-color: var(--neutral100);
+        border: 1px solid var(--neutral300);
         padding: 20px 12px;
         line-height: 16px;
         font-family: "Poppins";
@@ -31,7 +31,7 @@
         font-weight: 700;
         font-size: 20px;
         line-height: 28px;
-        color: $neutral1000;
+        color: var(--neutral1000);
         text-align: left;
       }
     }
@@ -52,8 +52,8 @@
 
     & > tr {
       & > td {
-        background-color: $neutral100;
-        border: 1px solid $neutral300;
+        background-color: var(--neutral100);
+        border: 1px solid var(--neutral300);
         padding: 12px;
         font-family: "Poppins";
         font-style: normal;
@@ -61,7 +61,7 @@
         font-size: 18px;
         line-height: 24px;
         text-align: left;
-        color: $neutral700;
+        color: var(--neutral700);
 
         & > ul > li {
           margin-left: 15px !important;
@@ -92,7 +92,7 @@
           font-weight: 700;
           font-size: 20px;
           line-height: 28px;
-          color: $neutral1000;
+          color: var(--neutral1000);
           width: fit-content;
           display: block;
           margin-bottom: 12px;

--- a/web/src/pages/pricingOld/components/categories/categories.module.scss
+++ b/web/src/pages/pricingOld/components/categories/categories.module.scss
@@ -11,8 +11,8 @@
   font-size: 16px;
 
   &.selected{
-    background-color: $primary700;
-    color: $neutral100;
+    background-color: var(--primary700);
+    color: var(--neutral100);
   }
   &:not(.selected){
     cursor: pointer;

--- a/web/src/pages/pricingOld/components/licenseCard/licenseCard.module.scss
+++ b/web/src/pages/pricingOld/components/licenseCard/licenseCard.module.scss
@@ -6,8 +6,8 @@
   padding: 20px;
   border-radius: 12px;
   position: relative;
-  box-shadow: 0px 0px 12px 0px $boxShadowLigh;
-  background-color: $neutral100;
+  box-shadow: 0px 0px 12px 0px var(--boxShadowLigh);
+  background-color: var(--neutral100);
 
   &__tag {
     display: block;
@@ -18,11 +18,11 @@
     text-align: center;
     border-radius: 3px;
     top: -12px;
-    border: 1px solid $neutral300;
+    border: 1px solid var(--neutral300);
     border-radius: 10px;
     height: auto;
     left: 75px;
-    background-color: $neutral100;;
+    background-color: var(--neutral100);;
 
     & > p {
       font-size: 12px;
@@ -41,14 +41,14 @@
       margin-bottom: 0;
     }
     &__popularTag {
-      background-color: $secondary600 !important;
+      background-color: var(--secondary600) !important;
       border-radius: 5px;
       padding: 3px 8px;
       width: fit-content;
       margin-left: auto;
       height: 18px;
       & > p {
-        color: $neutral100;
+        color: var(--neutral100);
         font-weight: 400;
         font-size: 12px;
       }
@@ -90,7 +90,7 @@
 
   &__features {
     padding-top: 8px;
-    border-top: 1px solid $neutral300;
+    border-top: 1px solid var(--neutral300);
     width: 100%;
     @include flexbox();
     @include justify-content(space-between);
@@ -186,7 +186,7 @@
     margin-top: 24px;
   }
   &__button:nth-of-type(2) {
-    background-color: $neutral100;
+    background-color: var(--neutral100);
     border: none;
   }
 }
@@ -212,7 +212,7 @@
     text-align: center;
     border-radius: 3px;
     top: -12px;
-    border: 1px solid $neutral300;
+    border: 1px solid var(--neutral300);
     border-radius: 10px;
     height: auto;
     left: 75px;

--- a/web/src/pages/pricingOld/components/licensesTable/licensesTable.module.scss
+++ b/web/src/pages/pricingOld/components/licensesTable/licensesTable.module.scss
@@ -31,7 +31,7 @@ table {
     left: 0;
     box-shadow: 0px 4px 8px 0px #0000001F;
     z-index: -1;
-    background-color: $neutral100;
+    background-color: var(--neutral100);
   }
 }
 
@@ -67,14 +67,14 @@ table {
           width: calc(100% - 70px);
         }
         &__popularTag {
-          background-color: $primary700;
+          background-color: var(--primary700);
           border-radius: 5px;
           padding: 3px 8px;
           width: fit-content;
           margin-left: auto;
           height: 18px;
           & > p {
-            color: $neutral100;
+            color: var(--neutral100);
             font-weight: 400;
             font-size: 12px;
           }
@@ -199,9 +199,9 @@ table {
       }
     }
     &__row {
-        background-color: $neutral100;
+        background-color: var(--neutral100);
       & > td {
-      border: 1px solid $neutral300;
+      border: 1px solid var(--neutral300);
       padding: 12px;
       line-height: 16px;
     }

--- a/web/src/pages/pricingOld/components/licensesTableMobile/elements/cardHeader/cardHeader.module.scss
+++ b/web/src/pages/pricingOld/components/licensesTableMobile/elements/cardHeader/cardHeader.module.scss
@@ -3,5 +3,5 @@
 
 .card__header {
     padding: 12px 20px;
-    border-bottom: 1px solid $neutral300;
+    border-bottom: 1px solid var(--neutral300);
 }

--- a/web/src/pages/pricingOld/components/licensesTableMobile/licensesTableMobile.module.scss
+++ b/web/src/pages/pricingOld/components/licensesTableMobile/licensesTableMobile.module.scss
@@ -21,13 +21,13 @@
   margin-top: 32px;
   width: 100%;
   border-radius: 12px;
-  border: 1px solid $neutral300;
+  border: 1px solid var(--neutral300);
   overflow: hidden;
-  background-color: $neutral100;
+  background-color: var(--neutral100);
 
   & > .card__header {
     padding: 12px 20px;
-    border-bottom: 1px solid $neutral300;
+    border-bottom: 1px solid var(--neutral300);
   }
 
   & > .card__row {
@@ -35,7 +35,7 @@
     
     & > div:nth-child(1) {
       padding: 12px;
-      border-right: 1px solid $neutral300;
+      border-right: 1px solid var(--neutral300);
       min-width: 140px;
       width: 140px;
       @include min-width($mobileXL) {
@@ -59,7 +59,7 @@
   }
 
   & > .card__row:not(:last-child) {
-    border-bottom: 1px solid $neutral300;
+    border-bottom: 1px solid var(--neutral300);
   }
 
   .icon {
@@ -84,14 +84,14 @@
 }
 
 .popularTag {
-  background-color: $primary700;
+  background-color: var(--primary700);
   border-radius: 5px;
   padding: 3px 8px;
   width: fit-content;
   margin-left: auto;
   height: 18px;
   & > p {
-    color: $neutral100;
+    color: var(--neutral100);
     font-weight: 400;
     font-size: 12px;
   }
@@ -101,9 +101,9 @@
   width: 100%;
   padding: 8px 12px;
   height: 40px;
-  border: 1px solid $neutral400;
+  border: 1px solid var(--neutral400);
   border-radius: 8px;
-  background-color: $neutral100;
+  background-color: var(--neutral100);
 }
 
 select {

--- a/web/src/pages/pricingOld/components/onPremisePanel/onPremisePanel.module.scss
+++ b/web/src/pages/pricingOld/components/onPremisePanel/onPremisePanel.module.scss
@@ -5,8 +5,8 @@
 .card__list {
   @include flex(0, 0, calc(100% - 64px));
   min-height: 236px;
-  background: $neutral100;
-  box-shadow: 0px 0px 12px $boxShadowLigh;
+  background: var(--neutral100);
+  box-shadow: 0px 0px 12px var(--boxShadowLigh);
   border-radius: 20px;
   padding: 24px;
   @include flexbox();
@@ -29,11 +29,11 @@
   }
   h5 {
     max-width: 777px;
-    color: $neutral1000;
+    color: var(--neutral1000);
     margin-bottom: 24px;
      text-align: center;
     & > span {
-      color: $primary700;
+      color: var(--primary700);
       font-family: $custom;
     }
   }
@@ -41,7 +41,7 @@
     max-width: 777px;
     text-align: center;
     
-    color: $neutral700
+    color: var(--neutral700)
   }
 
   & > button {

--- a/web/src/pages/pricingOld/index.module.scss
+++ b/web/src/pages/pricingOld/index.module.scss
@@ -2,5 +2,5 @@
 @import "../../styles/mixins";
 
 .slider {
-  background-color: $neutral1000 !important;
+  background-color: var(--neutral1000) !important;
 }

--- a/web/src/pages/pricingOld/sections/firstSection/firstSection.module.scss
+++ b/web/src/pages/pricingOld/sections/firstSection/firstSection.module.scss
@@ -32,7 +32,7 @@
     }
 
     p {
-      color: $neutral700;
+      color: var(--neutral700);
       margin-bottom: 80px;
 
       @include min-width($mobileXL) {
@@ -49,7 +49,7 @@
       max-width: 260px;
       margin: 0 auto;
       height: 48px;
-      background-color: $neutral200;
+      background-color: var(--neutral200);
       padding: 8px;
       border-radius: 12px;
       text-align: center;

--- a/web/src/pages/pricingOld/sections/secondSection/secondSection.module.scss
+++ b/web/src/pages/pricingOld/sections/secondSection/secondSection.module.scss
@@ -21,7 +21,7 @@
       height: 575px;
       right: -20px;
       top: 0;
-      background: $neutral200;
+      background: var(--neutral200);
       border-radius: 40px 0px 0px 40px;
       z-index: -1;
       @include min-width($mobileXL) {
@@ -105,7 +105,7 @@
           @include flex(0, 0, calc(66% - 32px));
         }
         a {
-          color: $primary700;
+          color: var(--primary700);
           &:hover {
             text-decoration: underline;
           }

--- a/web/src/pages/privacyPolicyOld/index.module.scss
+++ b/web/src/pages/privacyPolicyOld/index.module.scss
@@ -46,7 +46,7 @@
   }
 
   p {
-    color: $neutral700;
+    color: var(--neutral700);
   }
 
   .sectionMain {
@@ -70,7 +70,7 @@
       text-decoration: none;
 
       &.mainListTitle {
-        color: $neutral1000;
+        color: var(--neutral1000);
       }
     }
 
@@ -117,7 +117,7 @@
       }
 
       a {
-        color: $primary700;
+        color: var(--primary700);
         font-family: $base;
       }
 
@@ -132,7 +132,7 @@
             position: absolute;
             width: 5px;
             height: 5px;
-            background-color: $neutral700;
+            background-color: var(--neutral700);
             border-radius: 5px;
             top: 10px;
             left: -15px;

--- a/web/src/pages/privacyPolicyOld/table/table.module.scss
+++ b/web/src/pages/privacyPolicyOld/table/table.module.scss
@@ -22,8 +22,8 @@
       }
 
       & > th {
-        background-color: $neutral100;
-        border: 1px solid $neutral300;
+        background-color: var(--neutral100);
+        border: 1px solid var(--neutral300);
         padding: 20px 12px;
         line-height: 16px;
         font-family: "Poppins";
@@ -31,7 +31,7 @@
         font-weight: 700;
         font-size: 20px;
         line-height: 28px;
-        color: $neutral1000;
+        color: var(--neutral1000);
         text-align: left;
       }
     }
@@ -52,8 +52,8 @@
 
     & > tr {
       & > td {
-        background-color: $neutral100;
-        border: 1px solid $neutral300;
+        background-color: var(--neutral100);
+        border: 1px solid var(--neutral300);
         padding: 12px;
         font-family: "Poppins";
         font-style: normal;
@@ -61,7 +61,7 @@
         font-size: 18px;
         line-height: 24px;
         text-align: left;
-        color: $neutral700;
+        color: var(--neutral700);
 
         & > ul > li {
           margin-left: 15px !important;
@@ -92,7 +92,7 @@
           font-weight: 700;
           font-size: 20px;
           line-height: 28px;
-          color: $neutral1000;
+          color: var(--neutral1000);
           width: fit-content;
           display: block;
           margin-bottom: 12px;

--- a/web/src/pages/products/gatacaStudioOld/sections/fifthSection/fifthSection.module.scss
+++ b/web/src/pages/products/gatacaStudioOld/sections/fifthSection/fifthSection.module.scss
@@ -33,7 +33,7 @@
 
     video {
       max-width: 100%;
-      box-shadow: 0px 0px 16px 0px $boxShadowLigh;
+      box-shadow: 0px 0px 16px 0px var(--boxShadowLigh);
       @include min-width($desktopXL) {
         max-width: 982px;
       }
@@ -46,7 +46,7 @@
       height: 70%;
       bottom: -20px;
       left: -5px;
-      background: $neutral200;
+      background: var(--neutral200);
       border-radius: 11px;
       z-index: -1;
       padding: 0 5px;

--- a/web/src/pages/products/gatacaStudioOld/sections/firstSection/firstSection.module.scss
+++ b/web/src/pages/products/gatacaStudioOld/sections/firstSection/firstSection.module.scss
@@ -46,7 +46,7 @@
   }
 
   & > p {
-    color: $neutral700;
+    color: var(--neutral700);
   }
 
   & > .buttons_container {

--- a/web/src/pages/products/gatacaStudioOld/sections/fourthSection/fourthSection.module.scss
+++ b/web/src/pages/products/gatacaStudioOld/sections/fourthSection/fourthSection.module.scss
@@ -79,13 +79,13 @@
       height: fit-content;
       min-width: 220px;
       max-width: 220px;
-      background-color: $neutral100;
+      background-color: var(--neutral100);
       padding: 40px;
       border-radius: 20px;
       text-align: left;
       overflow: hidden;
       cursor: pointer;
-      box-shadow: 0px 0px 10px $boxShadowLigh;
+      box-shadow: 0px 0px 10px var(--boxShadowLigh);
       @include flexbox();
       @include flex-direction(column);
       @include align-items(flex-start);
@@ -112,7 +112,7 @@
       }
 
       & > .advantage__description {
-        color: $neutral700;
+        color: var(--neutral700);
       }
     }
   }

--- a/web/src/pages/products/gatacaStudioOld/sections/sixthSection/sixthSection.module.scss
+++ b/web/src/pages/products/gatacaStudioOld/sections/sixthSection/sixthSection.module.scss
@@ -79,8 +79,8 @@
 
     .plansSection__list {
       min-height: 164px;
-      background: $neutral100;
-      box-shadow: 0px 0px 12px $boxShadowLigh;
+      background: var(--neutral100);
+      box-shadow: 0px 0px 12px var(--boxShadowLigh);
       border-radius: 20px;
       padding: 20px;
       width: 232px;
@@ -100,8 +100,8 @@
         @include align-items(center);
 
         & > div {
-          background-color: $primary700;
-          color: $neutral100;
+          background-color: var(--primary700);
+          color: var(--neutral100);
         }
       }
 

--- a/web/src/pages/products/gatacaStudioOld/sections/thirdSection/thirdSection.module.scss
+++ b/web/src/pages/products/gatacaStudioOld/sections/thirdSection/thirdSection.module.scss
@@ -14,7 +14,7 @@
 
 .thirdSection {
   position: relative;
-  background-color: $neutral200;
+  background-color: var(--neutral200);
   border-radius: 20px;
   padding: 72px 40px;
   overflow-x: hidden;
@@ -146,6 +146,6 @@
   }
 
   .bullet__description {
-    color: $neutral700;
+    color: var(--neutral700);
   }
 }

--- a/web/src/pages/products/gatacaWalletOld/components/numberedText/numberedText.module.scss
+++ b/web/src/pages/products/gatacaWalletOld/components/numberedText/numberedText.module.scss
@@ -12,7 +12,7 @@
 }
 
 .number {
-    color: $primary200;
+    color: var(--primary200);
     margin-bottom: 24px;
 }
 
@@ -21,5 +21,5 @@
 }
 
 .description {
-    color: $neutral700
+    color: var(--neutral700)
 }

--- a/web/src/pages/products/gatacaWalletOld/components/singleFeature/singleFeature.module.scss
+++ b/web/src/pages/products/gatacaWalletOld/components/singleFeature/singleFeature.module.scss
@@ -15,7 +15,7 @@
   }
 
   & > .description {
-    color: $neutral700;
+    color: var(--neutral700);
 
     @include min-width($mobileXL) {
       margin-left: 70px;
@@ -54,7 +54,7 @@
   }
 
   & > .title {
-    color: $primary700;
+    color: var(--primary700);
 
     @include min-width($mobileXL) {
       margin-left: 70px;
@@ -66,7 +66,7 @@
   }
 
   & > .unselectedTitle {
-    color: $neutral1000;
+    color: var(--neutral1000);
     font-family: $base;
     font-size: 20px;
     font-weight: 700;

--- a/web/src/pages/products/gatacaWalletOld/sections/fifthSection/fifthSection.module.scss
+++ b/web/src/pages/products/gatacaWalletOld/sections/fifthSection/fifthSection.module.scss
@@ -48,7 +48,7 @@
     }
     
     & > .fifthSection__leftSide__description {
-      color: $neutral700;
+      color: var(--neutral700);
       margin-bottom: 40px;
       @include min-width($mobileXL) {
         margin-bottom: 52px;

--- a/web/src/pages/products/gatacaWalletOld/sections/firstSection/firstSection.module.scss
+++ b/web/src/pages/products/gatacaWalletOld/sections/firstSection/firstSection.module.scss
@@ -38,7 +38,7 @@
 
   & > div > a {
     display: block;
-    background-color: $primary700;
+    background-color: var(--primary700);
     border-radius: 8px;
     height: 52px;
     width: 178px;
@@ -49,12 +49,12 @@
     }
 
     &:hover {
-        background-color: $primary900;
+        background-color: var(--primary900);
     }
   }
 
   & > p {
-    color: $neutral700;
+    color: var(--neutral700);
   }
 }
 

--- a/web/src/pages/products/gatacaWalletOld/sections/fourthSection/fourthSection.module.scss
+++ b/web/src/pages/products/gatacaWalletOld/sections/fourthSection/fourthSection.module.scss
@@ -14,7 +14,7 @@
 
 .fourthSection {
   position: relative;
-  background-color: $neutral200;
+  background-color: var(--neutral200);
   border-radius: 20px;
   padding: 72px 40px;
   overflow-x: hidden;
@@ -132,6 +132,6 @@
   }
 
   .bullet__description {
-    color: $neutral700;
+    color: var(--neutral700);
   }
 }

--- a/web/src/pages/products/gatacaWalletOld/sections/sixthSection/components/credential/credentialExample.module.scss
+++ b/web/src/pages/products/gatacaWalletOld/sections/sixthSection/components/credential/credentialExample.module.scss
@@ -9,7 +9,7 @@
     border-radius: 8px;
     padding: 12px;
     margin-top: 10px;
-    background-color: $neutral100;
+    background-color: var(--neutral100);
     box-shadow: 2px 1px 6px 2px rgba(0, 0, 0, 0.0784313725);;
     @include flexbox();
     @include flex-direction(column);
@@ -35,7 +35,7 @@
 
     .mainData {
         margin-bottom: 24px;
-        color: $primary700
+        color: var(--primary700)
     }
 
     .datesContainer {

--- a/web/src/pages/products/gatacaWalletOld/sections/sixthSection/sixthSection.module.scss
+++ b/web/src/pages/products/gatacaWalletOld/sections/sixthSection/sixthSection.module.scss
@@ -135,7 +135,7 @@
   }
 
   & > div > p:nth-child(2) {
-    color: $neutral700;
+    color: var(--neutral700);
   }
 }
 
@@ -168,12 +168,12 @@
   cursor: not-allowed;
 
   & > rect {
-    fill: $neutral100;
-    stroke: $primary700;
+    fill: var(--neutral100);
+    stroke: var(--primary700);
   }
 
   & > path {
-    stroke: $primary700;
+    stroke: var(--primary700);
   }
 }
 
@@ -182,7 +182,7 @@
 
   &:hover {
     & > rect {
-      fill: $primary900;
+      fill: var(--primary900);
     }
   }
 }

--- a/web/src/pages/products/gatacaWalletOld/sections/thirdSection/thirdSection.module.scss
+++ b/web/src/pages/products/gatacaWalletOld/sections/thirdSection/thirdSection.module.scss
@@ -239,12 +239,12 @@
   cursor: not-allowed;
 
   & > rect {
-    fill: $neutral100;
-    stroke: $primary700;
+    fill: var(--neutral100);
+    stroke: var(--primary700);
   }
 
   & > path {
-    stroke: $primary700;
+    stroke: var(--primary700);
   }
 }
 
@@ -253,7 +253,7 @@
 
   &:hover {
     & > rect {
-      fill: $primary900;
+      fill: var(--primary900);
     }
   }
 }

--- a/web/src/pages/resources/blog/sections/firstSection/components/formSkeleton.module.scss
+++ b/web/src/pages/resources/blog/sections/firstSection/components/formSkeleton.module.scss
@@ -4,21 +4,21 @@
 .formSkeleton {
     & > div:nth-child(1) {
         width: 294px;
-        background: $skeletonBG;
+        background: var(--skeletonBG);
         height: 23px;
         border-radius: 3px;
     }
     & > div:nth-child(2) {
         width: 100%;
         margin-top: 4px;
-        background: $skeletonBG;
+        background: var(--skeletonBG);
         height: 40px;
         border-radius: 3px;
         margin-bottom: 18px;
     }
     & > div:nth-child(3) {
         width: 90%;
-        background: $skeletonBG;
+        background: var(--skeletonBG);
         height: 23px;
         border-radius: 3px;
         margin-bottom: 35px;
@@ -26,7 +26,7 @@
      & > div:nth-child(4) {
         width: 140px;
         margin: auto auto 17px;
-        background: $skeletonBG;
+        background: var(--skeletonBG);
         height: 42px;
         border-radius: 3px;
         margin-bottom: 17px;
@@ -116,7 +116,7 @@
     display: block;
     width: 128px;
     height: 393px;
-    background: linear-gradient(90deg, rgba(255, 255, 255, 0), $neutral100, rgba(255, 255, 255, 0));
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0), var(--neutral100), rgba(255, 255, 255, 0));
     content: "";
     animation: skeleton-animation 2s infinite;
     @include min-width($mobileXL) {

--- a/web/src/pages/resources/blog/sections/firstSection/firstSection.module.scss
+++ b/web/src/pages/resources/blog/sections/firstSection/firstSection.module.scss
@@ -37,16 +37,16 @@
   }
 
   & > p {
-    color: $neutral700;
+    color: var(--neutral700);
   }
 
   & > .buttons_container {
-    background-color: $neutral100;
+    background-color: var(--neutral100);
     padding: 20px 20px 4px;
     margin-top: 32px;
     border-radius: 12px;
     min-height: 284;
-    box-shadow: 0px 0px 10px $boxShadowLigh;
+    box-shadow: 0px 0px 10px var(--boxShadowLigh);
     @include flexbox();
     @include flex-direction(column);
     @include justify-content(space-between);
@@ -61,12 +61,12 @@
     }
 
     .form__label {
-      color: $neutral700;
+      color: var(--neutral700);
       margin-bottom: 24px;
     }
 
     .form__input {
-      color: $neutral900;
+      color: var(--neutral900);
       height: 32px;
       width: calc(100% - 24px) ;
       padding: 8px 12px;

--- a/web/src/pages/resources/blog/sections/secondSection/secondSection.module.scss
+++ b/web/src/pages/resources/blog/sections/secondSection/secondSection.module.scss
@@ -51,12 +51,12 @@
     display: none; /* Opera and Chrome */
   }
   .categorySelectedOption {
-    background-color: $neutral100;
-    border: 1px solid $primary700;
+    background-color: var(--neutral100);
+    border: 1px solid var(--primary700);
     padding: 8px;
     border-radius: 8px;
     margin-right: 32px;
-    color: $primary700;
+    color: var(--primary700);
     text-align: center;
     white-space: nowrap;
     cursor: none;
@@ -72,7 +72,7 @@
     cursor: pointer;
     @include flexbox();
     &:hover {
-      color: $primary700;
+      color: var(--primary700);
     }
   }
 

--- a/web/src/pages/resources/certifications/sections/firstSection/firstSection.module.scss
+++ b/web/src/pages/resources/certifications/sections/firstSection/firstSection.module.scss
@@ -20,8 +20,8 @@
     }
   }
   .certifications__cards {
-    background: $neutral100;
-    box-shadow: 0px 0px 20px $boxShadowLigh;
+    background: var(--neutral100);
+    box-shadow: 0px 0px 20px var(--boxShadowLigh);
     border-radius: 20px;
     padding: 40px;
     @include min-width($tabletXL) {
@@ -48,8 +48,8 @@
       }
       .buttonContainer {
         .purpleLink {
-          background-color: $primary700;
-          color: $primary100;
+          background-color: var(--primary700);
+          color: var(--primary100);
           padding: 12px 24px;
           height: auto;
           border-radius: 8px;
@@ -59,7 +59,7 @@
           @include align-items(center);
           cursor: pointer;
           &:hover {
-            background-color: $primary900;
+            background-color: var(--primary900);
           }
           margin: 0 auto;
           @include min-width($tabletXL) {

--- a/web/src/pages/resources/sections/firstSection/firstSection.module.scss
+++ b/web/src/pages/resources/sections/firstSection/firstSection.module.scss
@@ -50,7 +50,7 @@
       padding: 24px;
       border-radius: 20px;
       cursor: pointer;
-      filter: drop-shadow(0px 0px 10px $boxShadowLigh);
+      filter: drop-shadow(0px 0px 10px var(--boxShadowLigh));
       @include flexbox();
       @include flex-direction(column);
       @include align-items(center);
@@ -61,7 +61,7 @@
         margin-bottom: 26px;
       }
       & > .resource__description {
-        color: $neutral700;
+        color: var(--neutral700);
         text-align: center;
       }
     }

--- a/web/src/pages/resources/sections/secondSection/secondSection.module.scss
+++ b/web/src/pages/resources/sections/secondSection/secondSection.module.scss
@@ -44,12 +44,12 @@
   }
 
   .documentationEntry {
-    background-color: $neutral100;
+    background-color: var(--neutral100);
     padding: 20px;
     border-radius: 8px;
     max-width: 876px;
-    color: $primary700;
-    filter: drop-shadow(0px 0px 10px $boxShadowLigh);
+    color: var(--primary700);
+    filter: drop-shadow(0px 0px 10px var(--boxShadowLigh));
     @include flexbox();
     @include justify-content(space-between);
     @include align-items(center);

--- a/web/src/pages/termsOfServiceStudioOld/index.module.scss
+++ b/web/src/pages/termsOfServiceStudioOld/index.module.scss
@@ -46,7 +46,7 @@
   }
 
   p {
-    color: $neutral700;
+    color: var(--neutral700);
   }
 
   .sectionMain {
@@ -70,7 +70,7 @@
       text-decoration: none;
 
       &.mainListTitle {
-        color: $neutral1000;
+        color: var(--neutral1000);
       }
     }
 
@@ -117,7 +117,7 @@
       }
 
       a {
-        color: $primary700;
+        color: var(--primary700);
         font-family: $base;
       }
 
@@ -132,7 +132,7 @@
             position: absolute;
             width: 5px;
             height: 5px;
-            background-color: $neutral700;
+            background-color: var(--neutral700);
             border-radius: 5px;
             top: 10px;
             left: -15px;

--- a/web/src/pages/termsOfServiceStudioOld/table/table.module.scss
+++ b/web/src/pages/termsOfServiceStudioOld/table/table.module.scss
@@ -25,8 +25,8 @@
       }
 
       & > th {
-        background-color: $neutral100;
-        border: 1px solid $neutral300;
+        background-color: var(--neutral100);
+        border: 1px solid var(--neutral300);
         padding: 20px 12px;
         line-height: 16px;
         font-family: "Poppins";
@@ -34,7 +34,7 @@
         font-weight: 700;
         font-size: 20px;
         line-height: 28px;
-        color: $neutral1000;
+        color: var(--neutral1000);
         text-align: left;
       }
     }
@@ -55,8 +55,8 @@
 
     & > tr {
       & > td {
-        background-color: $neutral100;
-        border: 1px solid $neutral300;
+        background-color: var(--neutral100);
+        border: 1px solid var(--neutral300);
         padding: 12px;
         font-family: "Poppins";
         font-style: normal;
@@ -64,7 +64,7 @@
         font-size: 18px;
         line-height: 24px;
         text-align: left;
-        color: $neutral700;
+        color: var(--neutral700);
 
         & > ul > li {
           margin-left: 15px !important;
@@ -94,7 +94,7 @@
     font-weight: 700;
     font-size: 20px;
     line-height: 28px;
-    color: $neutral1000;
+    color: var(--neutral1000);
     width: fit-content;
     display: block;
     margin-bottom: 12px;

--- a/web/src/pages/termsOfUseOld/index.module.scss
+++ b/web/src/pages/termsOfUseOld/index.module.scss
@@ -46,7 +46,7 @@
   }
 
   p {
-    color: $neutral700;
+    color: var(--neutral700);
   }
 
   .sectionMain {
@@ -70,7 +70,7 @@
       text-decoration: none;
 
       &.mainListTitle {
-        color: $neutral1000;
+        color: var(--neutral1000);
       }
     }
 
@@ -117,7 +117,7 @@
       }
 
       a {
-        color: $primary700;
+        color: var(--primary700);
         font-family: $base;
       }
 
@@ -132,7 +132,7 @@
             position: absolute;
             width: 5px;
             height: 5px;
-            background-color: $neutral700;
+            background-color: var(--neutral700);
             border-radius: 5px;
             top: 10px;
             left: -15px;

--- a/web/src/pages/termsOfUseWalletOld/index.module.scss
+++ b/web/src/pages/termsOfUseWalletOld/index.module.scss
@@ -46,7 +46,7 @@
   }
 
   p {
-    color: $neutral700;
+    color: var(--neutral700);
   }
 
   .sectionMain {
@@ -70,7 +70,7 @@
       text-decoration: none;
 
       &.mainListTitle {
-        color: $neutral1000;
+        color: var(--neutral1000);
       }
     }
 
@@ -117,7 +117,7 @@
       }
 
       a {
-        color: $primary700;
+        color: var(--primary700);
         font-family: $base;
       }
 
@@ -132,7 +132,7 @@
             position: absolute;
             width: 5px;
             height: 5px;
-            background-color: $neutral700;
+            background-color: var(--neutral700);
             border-radius: 5px;
             top: 10px;
             left: -15px;

--- a/web/src/pages/useCasesSectors/components/categorySectors/categorySectors.module.scss
+++ b/web/src/pages/useCasesSectors/components/categorySectors/categorySectors.module.scss
@@ -12,7 +12,7 @@
       padding-top: 30px;
     }
     .description {
-      color: $neutral700;
+      color: var(--neutral700);
     }
   }
   .listSectors__items {

--- a/web/src/pages/useCasesSectors/components/listItems/listItems.module.scss
+++ b/web/src/pages/useCasesSectors/components/listItems/listItems.module.scss
@@ -3,7 +3,7 @@
 @import "../../../../styles/_types.scss";
 
 .container {
-  background: $neutral100;
+  background: var(--neutral100);
   box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.12);
   border-radius: 8px;
   padding: 16px;
@@ -12,7 +12,7 @@
     margin-bottom: 24px;
   }
   & > .description {    
-    color: $neutral700;
+    color: var(--neutral700);
   }
 }
 

--- a/web/src/pages/useCasesSectors/components/listSectors/listSectors.module.scss
+++ b/web/src/pages/useCasesSectors/components/listSectors/listSectors.module.scss
@@ -17,7 +17,7 @@
     }
   }
   > div {
-    background: $neutral100;
+    background: var(--neutral100);
     box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.12);
     border-radius: 8px;
     padding: 32px;
@@ -52,14 +52,14 @@
           opacity: 0;
         }
         &.opened {
-          background-color: $neutral200;
+          background-color: var(--neutral200);
           border-radius: 8px;
           display: block;
           .transitionContainer {
             transition: opacity 1500ms;
             opacity: 1;
             p {
-              color: $neutral1000;
+              color: var(--neutral1000);
               padding: 0 32px 32px;
           
               @include min-width($mobileXL) {
@@ -96,14 +96,14 @@
       max-height: 38px;
     }
     .description {
-      color: $neutral700;
+      color: var(--neutral700);
     }
     .linkMore {
-      color: $primary700;
+      color: var(--primary700);
       @include flexbox;
       @include align-items(center);
       &:hover {
-        color: $primary900;
+        color: var(--primary900);
       }
     }
   }

--- a/web/src/pages/useCasesSectors/education/sections/fifthSection/fifthSection.module.scss
+++ b/web/src/pages/useCasesSectors/education/sections/fifthSection/fifthSection.module.scss
@@ -54,7 +54,7 @@
         position: absolute;
         width: 67px;
         height: 427px;
-        background-color: $neutral200;
+        background-color: var(--neutral200);
         top: 235px;
         right: -20px;
         border-radius: 40px 0px 0px 40px;
@@ -80,13 +80,13 @@
       .story {
         height: fit-content;
         @include flex(0, 0, 300px);
-        background-color: $neutral100;
+        background-color: var(--neutral100);
         padding: 40px;
         border-radius: 20px;
         text-align: left;
         overflow: hidden;
         cursor: pointer;
-        box-shadow: 0px 0px 10px $boxShadowLigh;
+        box-shadow: 0px 0px 10px var(--boxShadowLigh);
         z-index: 1;
         @include flexbox();
         @include flex-direction(column);
@@ -111,7 +111,7 @@
           text-align: left;
         }
         .story__description {
-          color: $neutral700;
+          color: var(--neutral700);
           &.notOpened {
             display: -webkit-box;
             -webkit-line-clamp: 4;
@@ -131,7 +131,7 @@
           @include align-items(center);
           margin-top: 40px;
           a {
-            color: $primary700;
+            color: var(--primary700);
             &:hover {
               text-decoration: underline;
             }

--- a/web/src/pages/useCasesSectors/education/sections/secondSection/secondSection.module.scss
+++ b/web/src/pages/useCasesSectors/education/sections/secondSection/secondSection.module.scss
@@ -16,8 +16,8 @@
       height: 1565px;
       left: 50%;
       top: -130px;
-      background-image: -webkit-linear-gradient(transparent 0%, $primary700 40%, $primary700 60%, transparent 100%);
-      background: linear-gradient(transparent 0%, $primary700 40%, $primary700 60%,  transparent 100%);
+      background-image: -webkit-linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%, transparent 100%);
+      background: linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%,  transparent 100%);
       @include min-width($tabletXL) { 
         height: 1365px;
       }
@@ -47,8 +47,8 @@
       height: 240px;
       left: 50%;
       top: -250px;
-      background-image: -webkit-linear-gradient(transparent 0%, $primary700 40%, $primary700 60%, transparent 100%);
-      background: linear-gradient(transparent 0%, $primary700 40%, $primary700 60%, transparent 100%);
+      background-image: -webkit-linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%, transparent 100%);
+      background: linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%, transparent 100%);
     }
     @include min-width($tabletMD) {
       @include flexbox();
@@ -90,7 +90,7 @@
         @include flex(0, 0, 50%);
       }
       .number {
-        color: $primary100;
+        color: var(--primary100);
         font-family: $custom;
         font-style: normal;
         font-weight: 700;

--- a/web/src/pages/useCasesSectors/finance/sections/fifthSection/fifthSection.module.scss
+++ b/web/src/pages/useCasesSectors/finance/sections/fifthSection/fifthSection.module.scss
@@ -32,7 +32,7 @@
     }
     video {
       max-width: 100%;
-      box-shadow: 1px 1px 12px $boxShadowLigh;
+      box-shadow: 1px 1px 12px var(--boxShadowLigh);
       @include min-width($desktopXL) {
         max-width: 982px;
       }
@@ -44,7 +44,7 @@
       height: 70%;
       bottom: -20px;
       left: -5px;
-      background: $neutral200;
+      background: var(--neutral200);
       border-radius: 11px;
       z-index: -1;
       padding: 0 5px;

--- a/web/src/pages/useCasesSectors/finance/sections/secondSection/secondSection.module.scss
+++ b/web/src/pages/useCasesSectors/finance/sections/secondSection/secondSection.module.scss
@@ -20,8 +20,8 @@
       height: 1500px;
       left: 50%;
       top: -130px;
-      background-image: -webkit-linear-gradient(transparent 0%, $primary700 40%, $primary700 60%, transparent 100%);
-      background: linear-gradient(transparent 0%, $primary700 40%, $primary700 60%,  transparent 100%);
+      background-image: -webkit-linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%, transparent 100%);
+      background: linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%,  transparent 100%);
       @include min-width($tabletXL) { 
         height: 1365px;
       }
@@ -53,8 +53,8 @@
       height: 240px;
       left: 50%;
       top: -250px;
-      background-image: -webkit-linear-gradient(transparent 0%, $primary700 40%, $primary700 60%, transparent 100%);
-      background: linear-gradient(transparent 0%, $primary700 40%, $primary700 60%, transparent 100%);
+      background-image: -webkit-linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%, transparent 100%);
+      background: linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%, transparent 100%);
     }
 
     @include min-width($tabletMD) {
@@ -101,7 +101,7 @@
         @include flex(0, 0, 50%);
       }
       .number {
-        color: $primary100;
+        color: var(--primary100);
         font-family: $custom;
         font-style: normal;
         font-weight: 700;

--- a/web/src/pages/useCasesSectors/governmentOld/sections/fifthSection/fifthSection.module.scss
+++ b/web/src/pages/useCasesSectors/governmentOld/sections/fifthSection/fifthSection.module.scss
@@ -30,7 +30,7 @@
     }
     video {
       max-width: 100%;
-      box-shadow: 1px 1px 12px $boxShadowLigh;
+      box-shadow: 1px 1px 12px var(--boxShadowLigh);
       @include min-width($desktopXL) {
         max-width: 982px;
       }
@@ -42,7 +42,7 @@
       height: 70%;
       bottom: -20px;
       left: -5px;
-      background: $neutral200;
+      background: var(--neutral200);
       border-radius: 11px;
       z-index: -1;
       padding: 0 5px;

--- a/web/src/pages/useCasesSectors/governmentOld/sections/secondSection/secondSection.module.scss
+++ b/web/src/pages/useCasesSectors/governmentOld/sections/secondSection/secondSection.module.scss
@@ -16,8 +16,8 @@
       height: 1565px;
       left: 50%;
       top: -130px;
-      background-image: -webkit-linear-gradient(transparent 0%, $primary700 40%, $primary700 60%, transparent 100%);
-      background: linear-gradient(transparent 0%, $primary700 40%, $primary700 60%,  transparent 100%);
+      background-image: -webkit-linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%, transparent 100%);
+      background: linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%,  transparent 100%);
       @include min-width($tabletXL) { 
         height: 1365px;
       }
@@ -47,8 +47,8 @@
       height: 240px;
       left: 50%;
       top: -250px;
-      background-image: -webkit-linear-gradient(transparent 0%, $primary700 40%, $primary700 60%, transparent 100%);
-      background: linear-gradient(transparent 0%, $primary700 40%, $primary700 60%, transparent 100%);
+      background-image: -webkit-linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%, transparent 100%);
+      background: linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%, transparent 100%);
     }
     @include min-width($tabletMD) {
       @include flexbox();
@@ -90,7 +90,7 @@
         @include flex(0, 0, 50%);
       }
       .number {
-        color: $primary100;
+        color: var(--primary100);
         font-family: $custom;
         font-style: normal;
         font-weight: 700;

--- a/web/src/pages/useCasesSectors/sections/headerSection/headerSection.module.scss
+++ b/web/src/pages/useCasesSectors/sections/headerSection/headerSection.module.scss
@@ -16,12 +16,12 @@
     }
 
     h1 span {
-      color: $primary700;
+      color: var(--primary700);
       font-family: $custom;
     }
 
     p {
-      color: $neutral700;
+      color: var(--neutral700);
     }
     .buttonContainer {
       text-align: center;

--- a/web/src/pages/useCasesSectors/sections/useCasesAppliedSection/elements/categories.module.scss
+++ b/web/src/pages/useCasesSectors/sections/useCasesAppliedSection/elements/categories.module.scss
@@ -14,8 +14,8 @@
     min-width: 162px;
   }
   &.selected{
-    background-color: $primary700;
-    color: $neutral100;
+    background-color: var(--primary700);
+    color: var(--neutral100);
   }
   &:not(.selected){
     cursor: pointer;

--- a/web/src/pages/useCasesSectors/sections/useCasesAppliedSection/useCasesAppliedSection.module.scss
+++ b/web/src/pages/useCasesSectors/sections/useCasesAppliedSection/useCasesAppliedSection.module.scss
@@ -19,7 +19,7 @@
       margin-bottom: 30px;
     }
     p {
-      color: $neutral700;
+      color: var(--neutral700);
       margin-bottom: 80px;
       @include min-width($mobileXL) {
         margin-bottom: 60px;
@@ -31,7 +31,7 @@
       @include justify-content (center);
       max-width: 419px;
       margin: 0 auto;
-      background-color: $neutral200;
+      background-color: var(--neutral200);
       padding: 8px;
       border-radius: 12px;
       text-align: center;

--- a/web/src/pages/useCasesSectors/sections/useCasesSection/useCasesSection.module.scss
+++ b/web/src/pages/useCasesSectors/sections/useCasesSection/useCasesSection.module.scss
@@ -33,7 +33,7 @@
   }
   .useCasesSection__leftColumn{
     p {
-      color: $neutral700;
+      color: var(--neutral700);
       margin-bottom: 32px;
       @include min-width($tabletMD) {
         margin-bottom: 164px;

--- a/web/src/pages/useCasesSectors/web3/sections/fifthSection/fifthSection.module.scss
+++ b/web/src/pages/useCasesSectors/web3/sections/fifthSection/fifthSection.module.scss
@@ -32,7 +32,7 @@
     }
     video {
       max-width: 100%;
-      box-shadow: 1px 1px 12px $boxShadowLigh;
+      box-shadow: 1px 1px 12px var(--boxShadowLigh);
       @include min-width($desktopXL) {
         max-width: 982px;
       }
@@ -44,7 +44,7 @@
       height: 70%;
       bottom: -20px;
       left: -5px;
-      background: $neutral200;
+      background: var(--neutral200);
       border-radius: 11px;
       z-index: -1;
       padding: 0 5px;

--- a/web/src/pages/useCasesSectors/web3/sections/secondSection/secondSection.module.scss
+++ b/web/src/pages/useCasesSectors/web3/sections/secondSection/secondSection.module.scss
@@ -20,8 +20,8 @@
       height: 1500px;
       left: 50%;
       top: -130px;
-      background-image: -webkit-linear-gradient(transparent 0%, $primary700 40%, $primary700 60%, transparent 100%);
-      background: linear-gradient(transparent 0%, $primary700 40%, $primary700 60%,  transparent 100%);
+      background-image: -webkit-linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%, transparent 100%);
+      background: linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%,  transparent 100%);
       @include min-width($tabletXL) { 
         height: 1365px;
       }
@@ -53,8 +53,8 @@
       height: 240px;
       left: 50%;
       top: -250px;
-      background-image: -webkit-linear-gradient(transparent 0%, $primary700 40%, $primary700 60%, transparent 100%);
-      background: linear-gradient(transparent 0%, $primary700 40%, $primary700 60%, transparent 100%);
+      background-image: -webkit-linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%, transparent 100%);
+      background: linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%, transparent 100%);
     }
 
     @include min-width($tabletMD) {
@@ -101,7 +101,7 @@
         @include flex(0, 0, 50%);
       }
       .number {
-        color: $primary100;
+        color: var(--primary100);
         font-family: $custom;
         font-style: normal;
         font-weight: 700;

--- a/web/src/styles/_colors.scss
+++ b/web/src/styles/_colors.scss
@@ -4,96 +4,198 @@
   }
 */
 
-// Neutral
-$neutral100: #ffffff;
-$neutral200: #f2f2f2;
-$neutral300: #e4e4e4;
-$neutral400: #c6c6c8;
-$neutral500: #a9a9ac;
-$neutral600: #8c8c90;
-$neutral700: #707074;
-$neutral800: #545458;
-$neutral900: #39393c;
-$neutral1000: #1e1e20;
+.light__theme {
+  // --------------------------------------------------
+  // Color variables
+  // --------------------------------------------------
 
-// Primary
-$primary100: #f2f2ff;
-$primary200: #DEDEFB;
-$primary300: #CCCBF8;
-$primary400: #A5A4E8;
-$primary500: #8281D7;
-$primary600: #6361C7;
-$primary700: #4745B7;
-$primary800: #2F2D8B;
-$primary900: #1B1A5F;
-$primary1000: #0C0B33;
+  // Neutral
+  --neutral100: #ffffff;
+  --neutral200: #f2f2f2;
+  --neutral300: #e4e4e4;
+  --neutral400: #c6c6c8;
+  --neutral500: #a9a9ac;
+  --neutral600: #8c8c90;
+  --neutral700: #707074;
+  --neutral800: #545458;
+  --neutral900: #39393c;
+  --neutral1000: #1e1e20;
 
-// Secondary
-$secondary100: #E8FEFF;
-$secondary200: #BBF2F4;
-$secondary300: #8EE6E9;
-$secondary400: #54CCD0;
-$secondary500: #25B2B7;
-$secondary600: #00999E;
-$secondary700: #067A7E;
-$secondary800: #095C5E;
-$secondary900: #083D3E;
-$secondary1000: #061E1F;
+  // Primary
+  --primary100: #f2f2ff;
+  --primary200: #DEDEFB;
+  --primary300: #CCCBF8;
+  --primary400: #A5A4E8;
+  --primary500: #8281D7;
+  --primary600: #6361C7;
+  --primary700: #4745B7;
+  --primary800: #2F2D8B;
+  --primary900: #1B1A5F;
+  --primary1000: #0C0B33;
 
-// Tertiary
-$tertiary100: #FFF2F6;
-$tertiary200: #FFD4E1;
-$tertiary300: #FFB6CD;
-$tertiary400: #F486A7;
-$tertiary500: #E85A84;
-$tertiary600: #DC3164;
-$tertiary700: #B22851;
-$tertiary800: #891E3E;
-$tertiary900: #5F152B;
-$tertiary1000: #360C18;
+  // Secondary
+  --secondary100: #E8FEFF;
+  --secondary200: #BBF2F4;
+  --secondary300: #8EE6E9;
+  --secondary400: #54CCD0;
+  --secondary500: #25B2B7;
+  --secondary600: #00999E;
+  --secondary700: #067A7E;
+  --secondary800: #095C5E;
+  --secondary900: #083D3E;
+  --secondary1000: #061E1F;
 
-// Success
-$success100: #D9FADF;
-$success200: #80CA8D;
-$success300: #3D9A4E;
-$success400: #186927;
-$success500: #04380E;
+  // Tertiary
+  --tertiary100: #FFF2F6;
+  --tertiary200: #FFD4E1;
+  --tertiary300: #FFB6CD;
+  --tertiary400: #F486A7;
+  --tertiary500: #E85A84;
+  --tertiary600: #DC3164;
+  --tertiary700: #B22851;
+  --tertiary800: #891E3E;
+  --tertiary900: #5F152B;
+  --tertiary1000: #360C18;
 
-// Alert
-$alert100: #FFDEDF;
-$alert200: #EE888C;
-$alert300: #DC3D43;
-$alert400: #8D1A1E;
-$alert500: #3D0608;
+  // Success
+  --success100: #D9FADF;
+  --success200: #80CA8D;
+  --success300: #3D9A4E;
+  --success400: #186927;
+  --success500: #04380E;
 
-// Warning
-$warning100: #FFF6CA;
-$warning200: #FBE263;
-$warning300: #F7CE00;
-$warning400: #B99B08;
-$warning500: #7A680B;
+  // Alert
+  --alert100: #FFDEDF;
+  --alert200: #EE888C;
+  --alert300: #DC3D43;
+  --alert400: #8D1A1E;
+  --alert500: #3D0608;
 
-// Info
-$info100: #E4F3FF;
-$info200: #6FB8F8;
-$info300: #0081F1;
-$info400: #07549A;
-$info500: #062542;
+  // Warning
+  --warning100: #FFF6CA;
+  --warning200: #FBE263;
+  --warning300: #F7CE00;
+  --warning400: #B99B08;
+  --warning500: #7A680B;
 
-// Skeletons
-$skeletonBG: #e0e0e0;
+  // Info
+  --info100: #E4F3FF;
+  --info200: #6FB8F8;
+  --info300: #0081F1;
+  --info400: #07549A;
+  --info500: #062542;
 
-// Grey
-$grey600: #757575;
+  // Skeletons
+  --skeletonBG: var(--neutral300);
 
-// Orange
-$orange: #EF6F00;
+  // Orange
+  --orange: #EF6F00;
 
-// Box Shadows
-$boxShadowLigh: rgba(12, 11, 51, 0.12);
+  // Box Shadows
+  --boxShadowLigh: rgba(12, 11, 51, 0.12);
 
-// Gradients
+  // Gradients
 
-$primaryGradient: linear-gradient(180deg, $primary700 0%, $primary1000 100%);
-$tealGradient: linear-gradient(180deg, $secondary600 0%, $secondary1000 100%);
-$tertiaryGradient: linear-gradient(180deg, $tertiary600 0%, $tertiary1000 100%);
+  --primaryGradient: linear-gradient(180deg, var(--primary700) 0%, var(--primary1000) 100%);
+  --tealGradient: linear-gradient(180deg, var(--secondary600) 0%, var(--secondary1000) 100%);
+  --tertiaryGradient: linear-gradient(180deg, var(--tertiary600) 0%, var(--tertiary1000) 100%);
+
+}
+
+.dark__theme {
+  // --------------------------------------------------
+  // Color variables
+  // --------------------------------------------------
+
+  // Neutral
+  --neutral100: #1E1E20;
+  --neutral200: #39393C;
+  --neutral300: #545458;
+  --neutral400: #707074;
+  --neutral500: #8C8C90;
+  --neutral600: #A9A9AC;
+  --neutral700: #C6C6C8;
+  --neutral800: #E4E4E4;
+  --neutral900: #F2F2F2;
+  --neutral1000: #FFFFFF;
+
+  // Primary
+  --primary100: #0C0B33;
+  --primary200: #1B1A5F;
+  --primary300: #2F2D8B;
+  --primary400: #4745B7;
+  --primary500: #6361C7;
+  --primary600: #8281D7;
+  --primary700: #A5A4E8;
+  --primary800: #CCCBF8;
+  --primary900: #DEDEFB;
+  --primary1000: #F2F2FF;
+
+  // Secondary
+  --secondary100: #061E1F;
+  --secondary200: #083D3E;
+  --secondary300: #095C5E;
+  --secondary400: #067A7E;
+  --secondary500: #00999E;
+  --secondary600: #25B2B7;
+  --secondary700: #54CCD0;
+  --secondary800: #8EE6E9;
+  --secondary900: #BBF2F4;
+  --secondary1000: #E8FEFF;
+
+  // Tertiary
+  --tertiary100: #360C18;
+  --tertiary200: #5F152B;
+  --tertiary300: #891E3E;
+  --tertiary400: #B22851;
+  --tertiary500: #DC3164;
+  --tertiary600: #E85A84;
+  --tertiary700: #F486A7;
+  --tertiary800: #FFB6CD;
+  --tertiary900: #FFD4E1;
+  --tertiary1000: #FFF2F6;
+
+  // Success
+  --success100: #04380E;
+  --success200: #186927;
+  --success300: #3D9A4E;
+  --success400: #80CA8D;
+  --success500: #D9FADF;
+
+  // Alert
+  --alert100: #3D0608;
+  --alert200: #8D1A1E;
+  --alert300: #DC3D43;
+  --alert400: #EE888C;
+  --alert500: #FFDEDF;
+
+  // Warning
+  --warning100: #7A680B;
+  --warning200: #B99B08;
+  --warning300: #F7CE00;
+  --warning400: #FBE263;
+  --warning500: #FFF6CA;
+
+  // Info
+  --info100: #062542;
+  --info200: #07549A;
+  --info300: #0081F1;
+  --info400: #6FB8F8;
+  --info500: #E4F3FF;
+
+  // Skeletons
+  --skeletonBG: var(--neutral300);
+
+  // Orange
+  --orange: #EF6F00;
+
+  // Box Shadows
+  --boxShadowLigh: rgba(232, 232, 241, 0.12);
+
+  // Gradients
+
+  --primaryGradient: linear-gradient(180deg, var(--primary700) 0%, var(--primary1000) 100%);
+  --tealGradient: linear-gradient(180deg, var(--secondary600) 0%, var(--secondary1000) 100%);
+  --tertiaryGradient: linear-gradient(180deg, var(--tertiary600) 0%, var(--tertiary1000) 100%);
+}
+

--- a/web/src/styles/_reset.scss
+++ b/web/src/styles/_reset.scss
@@ -50,9 +50,8 @@ body {
 	line-height: 1;
     min-height: 100vh;
     margin: 0;
-    background-color: $neutral100;
-    color: $neutral1000;
-
+    background-color: var(--neutral100);
+    color: var(--neutral1000);
     & > div {
         height: 100%;
         overflow-x: hidden;
@@ -87,10 +86,10 @@ table {
 }
 
 a {
-    color: $neutral1000;
+    color: var(--neutral1000);
     text-decoration: none;
     &:hover {
-        color: $primary700;
+        color: var(--primary700);
     }
 }
 
@@ -100,10 +99,110 @@ button {
 
 // hr styles
 hr {
-    border: 1px solid $neutral300;
+    border: 1px solid var(--neutral300);
 }
 
 // bolds
 strong, b {
     font-weight: 700;
 }
+
+/* We need to also added it to the body for those pages that aren't created as Strapi Pages */
+body {
+    // --------------------------------------------------
+    // Color variables
+    // --------------------------------------------------
+
+    // Neutral
+    --neutral100: #ffffff;
+    --neutral200: #f2f2f2;
+    --neutral300: #e4e4e4;
+    --neutral400: #c6c6c8;
+    --neutral500: #a9a9ac;
+    --neutral600: #8c8c90;
+    --neutral700: #707074;
+    --neutral800: #545458;
+    --neutral900: #39393c;
+    --neutral1000: #1e1e20;
+
+    // Primary
+    --primary100: #f2f2ff;
+    --primary200: #DEDEFB;
+    --primary300: #CCCBF8;
+    --primary400: #A5A4E8;
+    --primary500: #8281D7;
+    --primary600: #6361C7;
+    --primary700: #4745B7;
+    --primary800: #2F2D8B;
+    --primary900: #1B1A5F;
+    --primary1000: #0C0B33;
+
+    // Secondary
+    --secondary100: #E8FEFF;
+    --secondary200: #BBF2F4;
+    --secondary300: #8EE6E9;
+    --secondary400: #54CCD0;
+    --secondary500: #25B2B7;
+    --secondary600: #00999E;
+    --secondary700: #067A7E;
+    --secondary800: #095C5E;
+    --secondary900: #083D3E;
+    --secondary1000: #061E1F;
+
+    // Tertiary
+    --tertiary100: #FFF2F6;
+    --tertiary200: #FFD4E1;
+    --tertiary300: #FFB6CD;
+    --tertiary400: #F486A7;
+    --tertiary500: #E85A84;
+    --tertiary600: #DC3164;
+    --tertiary700: #B22851;
+    --tertiary800: #891E3E;
+    --tertiary900: #5F152B;
+    --tertiary1000: #360C18;
+
+    // Success
+    --success100: #D9FADF;
+    --success200: #80CA8D;
+    --success300: #3D9A4E;
+    --success400: #186927;
+    --success500: #04380E;
+
+    // Alert
+    --alert100: #FFDEDF;
+    --alert200: #EE888C;
+    --alert300: #DC3D43;
+    --alert400: #8D1A1E;
+    --alert500: #3D0608;
+
+    // Warning
+    --warning100: #FFF6CA;
+    --warning200: #FBE263;
+    --warning300: #F7CE00;
+    --warning400: #B99B08;
+    --warning500: #7A680B;
+
+    // Info
+    --info100: #E4F3FF;
+    --info200: #6FB8F8;
+    --info300: #0081F1;
+    --info400: #07549A;
+    --info500: #062542;
+
+    // Skeletons
+    --skeletonBG: var(--neutral300);
+
+    // Orange
+    --orange: #EF6F00;
+
+    // Box Shadows
+    --boxShadowLigh: rgba(12, 11, 51, 0.12);
+
+    // Gradients
+
+    --primaryGradient: linear-gradient(180deg, var(--primary700) 0%, var(--primary1000) 100%);
+    --tealGradient: linear-gradient(180deg, var(--secondary600) 0%, var(--secondary1000) 100%);
+    --tertiaryGradient: linear-gradient(180deg, var(--tertiary600) 0%, var(--tertiary1000) 100%);
+
+}
+

--- a/web/src/styles/globals.module.scss
+++ b/web/src/styles/globals.module.scss
@@ -794,18 +794,18 @@
 
     // Colors 
     .neutral700 {
-        color: $neutral700
+        color: var(--neutral700)
     }
 
     .neutral1000 {
-        color: $neutral1000
+        color: var(--neutral1000)
     }
 
     .primary200{
-        color: $primary200
+        color: var(--primary200)
     }
     .primary700 {
-        color: $primary700
+        color: var(--primary700)
     }
 
     // Radius
@@ -878,7 +878,9 @@
     }
 
     // Background vertical lines
-    body {
+    #mainLayout__container{
+        position: relative;
+        z-index: 1;
         &::before {
             content: '';
             position: fixed;
@@ -889,34 +891,37 @@
             left: 50%;
             transform: translate(-50%, -50%);
             background:
-                repeating-linear-gradient(#E4E4E4,
-                    #E4E4E4 3px,
+                repeating-linear-gradient(var(--neutral300),
+                    var(--neutral300) 3px,
                     transparent 3px,
                     transparent 6px) 0%,
-                repeating-linear-gradient(#E4E4E4,
-                        #E4E4E4 3px,
-                        transparent 3px,
-                        transparent 6px)25%,
-                repeating-linear-gradient(#E4E4E4,
-                        #E4E4E4 3px,
-                        transparent 3px,
-                        transparent 6px)50%,
-                repeating-linear-gradient(#E4E4E4,
-                        #E4E4E4 3px,
-                        transparent 3px,
-                        transparent 6px)75%,
-                repeating-linear-gradient(#E4E4E4,
-                        #E4E4E4 3px,
-                        transparent 3px,
-                        transparent 6px)100%;
+                repeating-linear-gradient(var(--neutral300),
+                    var(--neutral300) 3px,
+                    transparent 3px,
+                    transparent 6px)25%,
+                repeating-linear-gradient(var(--neutral300),
+                    var(--neutral300) 3px,
+                    transparent 3px,
+                    transparent 6px)50%,
+                repeating-linear-gradient(var(--neutral300),
+                    var(--neutral300) 3px,
+                    transparent 3px,
+                    transparent 6px)75%,
+                repeating-linear-gradient(var(--neutral300),
+                    var(--neutral300) 3px,
+                    transparent 3px,
+                    transparent 6px)100%;
             background-size: 1px 100%;
             background-repeat: repeat-y;
+
             @include min-width($mobileXL) {
                 width: calc(100% - 80px);
             }
+
             @include min-width($desktopMD) {
                 width: calc(100% - 120px);
             }
+
             @media (min-width: 1304px) {
                 width: 100%;
                 max-width: 1184px;

--- a/web/src/templates/blog/components/introBlogSkeleton/introBlogSkeleton.module.scss
+++ b/web/src/templates/blog/components/introBlogSkeleton/introBlogSkeleton.module.scss
@@ -124,7 +124,7 @@
   border-radius: 8px;
 }
 .skeleton {
-    background: $skeletonBG;
+    background: var(--skeletonBG);
     overflow: hidden;
 }
 
@@ -133,7 +133,7 @@
     display: block;
     width: 128px;
     height: 500px;
-    background: linear-gradient(90deg, rgba(255, 255, 255, 0), $neutral100, rgba(255, 255, 255, 0));
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0), var(--neutral100), rgba(255, 255, 255, 0));
     content: "";
     animation: skeleton-animation 2s infinite;
 }

--- a/web/src/templates/blog/sections/secondSection/secondSection.module.scss
+++ b/web/src/templates/blog/sections/secondSection/secondSection.module.scss
@@ -40,16 +40,16 @@
   }
 
   & > p {
-    color: $neutral700;
+    color: var(--neutral700);
   }
 
   & > .buttons_container {
-    background-color: $neutral100;
+    background-color: var(--neutral100);
     padding: 20px 20px 4px;
     margin-top: 32px;
     border-radius: 12px;
     min-height: 284;
-    filter: drop-shadow(0px 0px 10px $boxShadowLigh);
+    filter: drop-shadow(0px 0px 10px var(--boxShadowLigh));
     @include flexbox();
     @include flex-direction(column);
     @include justify-content(space-between);
@@ -64,12 +64,12 @@
     }
 
     .form__label {
-      color: $neutral700;
+      color: var(--neutral700);
       margin-bottom: 24px;
     }
 
     .form__input {
-      color: $neutral900;
+      color: var(--neutral900);
       height: 32px;
       width: calc(100% - 24px) ;
       padding: 8px 12px;
@@ -104,11 +104,11 @@
     margin-bottom: 0;
   }
   h6 {
-    color: $neutral1000;
+    color: var(--neutral1000);
     margin-bottom: 4px;
   }
   p {
-    color: $neutral700;
+    color: var(--neutral700);
   }
   & > div {
     @include flexbox();

--- a/web/src/templates/page/components/introBlogSkeleton/pageSkeleton.module.scss
+++ b/web/src/templates/page/components/introBlogSkeleton/pageSkeleton.module.scss
@@ -19,7 +19,7 @@
 }
 
 .skeleton {
-  background: $skeletonBG;
+  background: var(--skeletonBG);
   overflow: hidden;
   width: 100%;
   height: 400px;
@@ -32,7 +32,7 @@
     display: block;
     width: 128px;
     height: 500px;
-    background: linear-gradient(90deg, rgba(255, 255, 255, 0), $neutral100, rgba(255, 255, 255, 0));
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0), var(--neutral100), rgba(255, 255, 255, 0));
     content: "";
     animation: skeleton-animation 2s infinite;
 }

--- a/web/src/templates/page/pageTemplate.module.scss
+++ b/web/src/templates/page/pageTemplate.module.scss
@@ -1,0 +1,9 @@
+@import './src/styles/_colors.scss';
+
+.dark__theme, .light__theme {
+  background-color: var(--neutral100);
+}
+
+
+
+

--- a/web/src/templates/page/pageTemplate.module.scss.d.ts
+++ b/web/src/templates/page/pageTemplate.module.scss.d.ts
@@ -1,0 +1,2 @@
+export const dark__theme: string
+export const light__theme: string

--- a/web/src/templates/page/pageTemplate.tsx
+++ b/web/src/templates/page/pageTemplate.tsx
@@ -4,6 +4,7 @@ import Highlight from "./sections/components/shared/Highlight/Highlight"
 import { PageModel } from "../../interfaces/interfaces"
 import PageSkeleton from "./components/introBlogSkeleton/PageSkeleton"
 import AllSectionsTemplate from "./sections/AllSectionsTemplate"
+import * as styles from "./pageTemplate.module.scss"
 
 const PageTemplate: React.FC = (props: any) => {
   const [page, setPage] = React.useState<PageModel | undefined>()
@@ -30,8 +31,13 @@ const PageTemplate: React.FC = (props: any) => {
       })
   }
 
+  const pageTheme = pageData?.darkTheme
+
   return (
-    <Layout seoData={pageData?.seo}>
+    <Layout
+      className={pageTheme ? styles?.dark__theme : styles?.light__theme}
+      seoData={pageData?.seo}
+    >
       <>
         {pageData ? (
           <AllSectionsTemplate

--- a/web/src/templates/page/sections/AllSectionsTemplate.tsx
+++ b/web/src/templates/page/sections/AllSectionsTemplate.tsx
@@ -146,7 +146,7 @@ const AllSectionsTemplate: React.FC<PageModel> = props => {
         {__component === "pricing.cloud" && (
           <PricingInfo
             idItem={idItem}
-            headingOnPremise={headingOnPremise?.data?.attributes}
+            headingOnPremise={headingOnPremise}
             segmentedButtons={buttons?.data}
             index={0}
             switchLabel={switchLabel}

--- a/web/src/templates/page/sections/components/generic/brandButton/brandButton.module.scss
+++ b/web/src/templates/page/sections/components/generic/brandButton/brandButton.module.scss
@@ -3,7 +3,7 @@
 
 
 .brandButton {
-    background-color: $neutral1000;
+    background-color: var(--neutral1000);
     border: 1px solid #A6A6A6;
     border-radius: 8px;
     @include flexbox();
@@ -35,11 +35,11 @@
         max-width: 150px;
     }
     &.whiteColor {
-        background-color: $neutral100;
-        border: 1px solid $neutral1000;
+        background-color: var(--neutral100);
+        border: 1px solid var(--neutral1000);
     }
     &.blackColor {
-        background-color: $neutral1000;
+        background-color: var(--neutral1000);
         border: 1px solid #A6A6A6;
     }
 }

--- a/web/src/templates/page/sections/components/generic/button/button.module.scss
+++ b/web/src/templates/page/sections/components/generic/button/button.module.scss
@@ -2,8 +2,8 @@
 @import "../../../../../../styles/mixins.scss";
 
 .buttonStrapi {
-    background-color: $primary700;
-    color: $neutral100;
+    background-color: var(--primary700);
+    color: var(--neutral100);
     padding: 12px 24px;
     height: 48px;
     border-radius: 8px;
@@ -16,55 +16,55 @@
     width: fit-content;
     box-sizing: border-box;
     &:hover {
-        background-color: $primary900;
-        color: $neutral100;
+        background-color: var(--primary900);
+        color: var(--neutral100);
     }
     &:focus {
-        box-shadow: inset 0px 0px 0px 2px $primary300;
+        box-shadow: inset 0px 0px 0px 2px var(--primary300);
     }
     &:focus-visible {
-        outline: $primary300 auto 2px;
+        outline: var(--primary300) auto 2px;
     }
     &.fullWidthButton {
         width: 100%;
     }
     &.disabled {
-        background-color: $neutral400;
-        color: $neutral500;
+        background-color: var(--neutral400);
+        color: var(--neutral500);
         pointer-events: none;
     }
     &.outlineButton {
         background-color: transparent;
-        border: 1px solid $primary700;
-        color: $neutral1000;
+        border: 1px solid var(--primary700);
+        color: var(--neutral1000);
         &:hover {
-            color: $primary700;
+            color: var(--primary700);
         }
         &.disabled {
             background-color: transparent;
-            border: 1px solid $neutral500;
-            color: $neutral500;
+            border: 1px solid var(--neutral500);
+            color: var(--neutral500);
         }
     }
     &.text {
         border: none;
         background-color: transparent;
-        color: $neutral1000;
+        color: var(--neutral1000);
         &:hover {
-            color: $primary700;
-            background-color: $neutral200;
+            color: var(--primary700);
+            background-color: var(--neutral200);
         }
         &:focus {
-            background-color: $neutral200;
+            background-color: var(--neutral200);
             box-shadow: none;
         }
         &:focus-visible {
-            color: $primary700;
-            background-color: $neutral200;
+            color: var(--primary700);
+            background-color: var(--neutral200);
             outline: none;
         }
         &.disabled {
-            color: $neutral500;
+            color: var(--neutral500);
         }
         &.noPadding {
             padding: 0;
@@ -86,49 +86,49 @@
         height: 40px;
     }
     &.whiteColor {
-        background-color: $neutral100;
-        color: $neutral1000;
-        border: 1px solid $neutral100;
+        background-color: var(--neutral100);
+        color: var(--neutral1000);
+        border: 1px solid var(--neutral100);
         &:hover {
-            background-color: $neutral200;
+            background-color: var(--neutral200);
         }
         &:focus {
-            box-shadow: inset 0px 0px 0px 2px $neutral300;
+            box-shadow: inset 0px 0px 0px 2px var(--neutral300);
         }
         &:focus-visible {
-            outline: $neutral300 auto 2px;
+            outline: var(--neutral300) auto 2px;
         }
         &.outlineButton {
             background-color: transparent;
-            border: 1px solid $neutral100;
-            color: $neutral100;
+            border: 1px solid var(--neutral100);
+            color: var(--neutral100);
             &:hover {
                 background-color: rgba(255, 255, 255, 0.20);
             }
             &.disabled {
                 background-color: transparent;
-                border: 1px solid $neutral500;
-                color: $neutral500;
+                border: 1px solid var(--neutral500);
+                color: var(--neutral500);
             }
         }
         &.text {
             border: none;
             background-color: transparent;
-            color: $neutral100;
+            color: var(--neutral100);
             &:hover {
-                color: $neutral100;
-                background-color: $neutral300;
+                color: var(--neutral100);
+                background-color: var(--neutral300);
             }
             &:focus {
-                background-color: $neutral300;
-                box-shadow: inset 0px 0px 0px 2px $neutral300;
+                background-color: var(--neutral300);
+                box-shadow: inset 0px 0px 0px 2px var(--neutral300);
             }
             &:focus-visible {
-                background-color: $neutral300;
-                outline: $neutral300 auto 2px;
+                background-color: var(--neutral300);
+                outline: var(--neutral300) auto 2px;
             }
             &.disabled {
-                color: $neutral500;
+                color: var(--neutral500);
                 background-color: transparent;
             }
             &.noPadding {
@@ -146,63 +146,63 @@
             }
         }
         &.disabled {
-            background-color: $neutral400;
-            color: $neutral500;
+            background-color: var(--neutral400);
+            color: var(--neutral500);
             border: none;
         }
     }
 
     &.blackColor {
-        background-color: $neutral1000;
-        color: $neutral100;
+        background-color: var(--neutral1000);
+        color: var(--neutral100);
         &:hover {
-            background-color: $neutral800;
+            background-color: var(--neutral800);
         }
         &:focus {
-            box-shadow: inset 0px 0px 0px 2px $neutral300;
+            box-shadow: inset 0px 0px 0px 2px var(--neutral300);
         }
         &:focus-visible {
-            outline: $neutral300 auto 2px;
+            outline: var(--neutral300) auto 2px;
         }
         &.outlineButton {
             background-color: transparent;
-            border: 1px solid $neutral1000;
-            color: $neutral1000;
+            border: 1px solid var(--neutral1000);
+            color: var(--neutral1000);
             &:hover {
                 background-color: rgba(0, 0, 0, 0.20);
             }
             &:focus {
                 background-color: rgba(0, 0, 0, 0.20);
-                box-shadow: inset 0px 0px 0px 1px $neutral600;
+                box-shadow: inset 0px 0px 0px 1px var(--neutral600);
             }
             &:focus-visible {
                 background-color: rgba(0, 0, 0, 0.20);
-                outline: $neutral600 auto 1px;
+                outline: var(--neutral600) auto 1px;
             }
             &.disabled {
-                color: $neutral500;
-                border: 1px solid $neutral500;
+                color: var(--neutral500);
+                border: 1px solid var(--neutral500);
                 background-color: transparent;
             }
         }
         &.text {
             border: none;
             background-color: transparent;
-            color: $neutral1000;
+            color: var(--neutral1000);
             &:hover {
-                color: $primary700;
-                background-color: $neutral200;
+                color: var(--primary700);
+                background-color: var(--neutral200);
             }
             &:focus {
                 box-shadow: none;
-                background-color: $neutral200;
+                background-color: var(--neutral200);
             }
             &:focus-visible {
                 outline: none;
-                background-color: $neutral200;
+                background-color: var(--neutral200);
             }
             &.disabled {
-                color: $neutral500;
+                color: var(--neutral500);
                 background-color: transparent;
             }
             &.noPadding {
@@ -218,61 +218,61 @@
             }
         }
         &.disabled {
-            color: $neutral500;
-            background-color: $neutral400;
+            color: var(--neutral500);
+            background-color: var(--neutral400);
         }
     }
     &.greyColor {
-        background-color: $neutral500;
-        color: $neutral100;
+        background-color: var(--neutral500);
+        color: var(--neutral100);
         &:hover {
-            background-color: $neutral800;
+            background-color: var(--neutral800);
         }
         &:focus {
-            box-shadow: inset 0px 0px 0px 2px $neutral300;
+            box-shadow: inset 0px 0px 0px 2px var(--neutral300);
         }
         &:focus-visible {
-            outline: $neutral300 auto 2px;
+            outline: var(--neutral300) auto 2px;
         }
         &.outlineButton {
             background-color: transparent;
-            border: 1px solid $neutral500;
-            color: $neutral1000;
+            border: 1px solid var(--neutral500);
+            color: var(--neutral1000);
             &:hover {
                 background-color: rgba(169, 169, 172, 0.20);
             }
             &:focus {
                 background-color: rgba(169, 169, 172, 0.20);
-                box-shadow: inset 0px 0px 0px 1px $neutral500;
+                box-shadow: inset 0px 0px 0px 1px var(--neutral500);
             }
             &:focus-visible {
                 background-color: rgba(169, 169, 172, 0.20);
-                outline: $neutral500 auto 1px;
+                outline: var(--neutral500) auto 1px;
             }
             &.disabled {
-                color: $neutral500;
-                border: 1px solid $neutral500;
+                color: var(--neutral500);
+                border: 1px solid var(--neutral500);
                 background-color: transparent;
             }
         }
         &.text {
             border: none;
             background-color: transparent;
-            color: $neutral700;
+            color: var(--neutral700);
             &:hover {
-                color: $primary700;
-                background-color: $neutral200;
+                color: var(--primary700);
+                background-color: var(--neutral200);
             }
             &:focus {
                 box-shadow: none;
-                background-color: $neutral200;
+                background-color: var(--neutral200);
             }
             &:focus-visible {
                 outline: none;
-                background-color: $neutral200;
+                background-color: var(--neutral200);
             }
             &.disabled {
-                color: $neutral500;
+                color: var(--neutral500);
                 background-color: transparent;
             }
             &.noPadding {
@@ -288,8 +288,8 @@
             }
         }
         &.disabled {
-            color: $neutral500;
-            background-color: $neutral400;
+            color: var(--neutral500);
+            background-color: var(--neutral400);
         }
     }
 }

--- a/web/src/templates/page/sections/components/generic/buttonIcon/buttonIcon.module.scss
+++ b/web/src/templates/page/sections/components/generic/buttonIcon/buttonIcon.module.scss
@@ -2,7 +2,7 @@
 @import "../../../../../../styles/mixins.scss";
 
 .buttonIcon {
-    background-color: $primary700;
+    background-color: var(--primary700);
     padding: 12px;
     height: 48px;
     width: 48px; 
@@ -10,17 +10,17 @@
     cursor: pointer;
     box-sizing: border-box;
     &:hover {
-        background-color: $primary900;
+        background-color: var(--primary900);
     }
     &.disabled {
-        background-color: $neutral400;
+        background-color: var(--neutral400);
         pointer-events: none;
     }
     &:focus {
-        box-shadow: inset 0px 0px 0px 2px $neutral300;
+        box-shadow: inset 0px 0px 0px 2px var(--neutral300);
     }
     &:focus-visible {
-        outline: $neutral300 auto 2px;
+        outline: var(--neutral300) auto 2px;
     }
     img {
         width: 24px;
@@ -39,68 +39,68 @@
         border-radius: 8px;
     }
     &.redColor {
-        background-color: $alert300;
+        background-color: var(--alert300);
         &:hover {
-            background-color: $alert400;
+            background-color: var(--alert400);
         }
         &.disabled {
-            background-color: $neutral400;
+            background-color: var(--neutral400);
         }
     }
     &.greenColor {
-        background-color: $success300;
+        background-color: var(--success300);
        
         &:hover {
-            background-color: $success400;
+            background-color: var(--success400);
         }
         &.disabled {
-            background-color: $neutral400;
+            background-color: var(--neutral400);
         }
 
     }
     &.yellowColor {
-        background-color: $warning300;
+        background-color: var(--warning300);
         &:hover {
-            background-color: $warning400;
+            background-color: var(--warning400);
         }
         &.disabled {
-            background-color: $neutral400;
+            background-color: var(--neutral400);
         }
     }
     &.blueColor {
-        background-color: $info300;
+        background-color: var(--info300);
         &:hover {
-            background-color: $info400;
+            background-color: var(--info400);
         }
         &.disabled {
-            background-color: $neutral400;
+            background-color: var(--neutral400);
         }
     }
     &.lightPurpleColor {
-        background-color: $primary100;
+        background-color: var(--primary100);
         &:hover {
-            background-color: $primary300;
+            background-color: var(--primary300);
         }
         &.disabled {
-            background-color: $neutral400;
+            background-color: var(--neutral400);
         }
     }
     &.tealColor {
-        background-color: $secondary600;
+        background-color: var(--secondary600);
         &:hover {
-            background-color: $secondary800;
+            background-color: var(--secondary800);
         }
         &.disabled {
-            background-color: $neutral400;
+            background-color: var(--neutral400);
         }
     }
     &.pinkColor {
-        background-color: $tertiary600;
+        background-color: var(--tertiary600);
         &:hover {
-            background-color: $tertiary800;
+            background-color: var(--tertiary800);
         }
         &.disabled {
-            background-color: $neutral400;
+            background-color: var(--neutral400);
         }
     }
 }

--- a/web/src/templates/page/sections/components/generic/chip/chip.module.scss
+++ b/web/src/templates/page/sections/components/generic/chip/chip.module.scss
@@ -2,8 +2,8 @@
 @import "../../../../../../styles/mixins.scss";
 
 .chipStrapi {
-    background-color: $neutral100;
-    color: $neutral1000;
+    background-color: var(--neutral100);
+    color: var(--neutral1000);
     padding: 4px 8px;
     height: 24px;
     border-radius: 4px;
@@ -19,7 +19,7 @@
         pointer-events: none;
     }
     &:hover {
-        background-color: $neutral200;
+        background-color: var(--neutral200);
     }
     &:focus {
         box-shadow: none;
@@ -28,28 +28,28 @@
         outline: none;
     }
     &:active {
-        color: $primary700;
+        color: var(--primary700);
         span {
             font-weight: 700;
         }
     }
     &.disabled {
-        background-color: $neutral400;
-        color: $neutral500;
+        background-color: var(--neutral400);
+        color: var(--neutral500);
         pointer-events: none;
     }
     &.redColor, &.greenColor, &.purpleColor, &.yellowColor, &.blueColor, &.greyColor, &.tealColor, &.pinkColor, &.blackColor {
         &.disabled {
-            background-color: $neutral400;
-            color: $neutral500;
+            background-color: var(--neutral400);
+            color: var(--neutral500);
             pointer-events: none;
         }
         &.outlineChip {
             background-color: transparent;
             &.disabled {
                 background-color: transparent;
-                border: 1px solid $neutral400;
-                color: $neutral400;
+                border: 1px solid var(--neutral400);
+                color: var(--neutral400);
             }
             &:hover {
                 background-color: transparent;
@@ -64,8 +64,8 @@
             border: none;
             background-color: transparent;
             &.disabled {
-                background-color: $neutral400;
-                color: $neutral500;
+                background-color: var(--neutral400);
+                color: var(--neutral500);
                 border: none;
                 pointer-events: none;
             }
@@ -87,24 +87,24 @@
     }
     &.outlineChip {
         background-color: transparent;
-        border: 1px solid $neutral100;
-        color: $neutral100;
+        border: 1px solid var(--neutral100);
+        color: var(--neutral100);
         &:hover {
-            border: 1px solid $neutral200;
-            color: $neutral200;
+            border: 1px solid var(--neutral200);
+            color: var(--neutral200);
         }
         &:active, &:focus {
-            border: 1px solid $neutral200;
-            color: $primary700;
+            border: 1px solid var(--neutral200);
+            color: var(--primary700);
         }
     }
     &.text {
-        color: $neutral100;
+        color: var(--neutral100);
         &:hover {
-            color: $neutral200;
+            color: var(--neutral200);
         }
         &:active, &:focus {
-            border: 1px solid $neutral100;  
+            border: 1px solid var(--neutral100);  
         }
     }
     img {
@@ -114,259 +114,259 @@
 
     // Colors
     &.purpleColor {
-        background-color: $primary200;
-        color: $primary700;
+        background-color: var(--primary200);
+        color: var(--primary700);
         &:hover {
-            background-color: $primary400;
+            background-color: var(--primary400);
         }
         &.outlineChip {
-            border: 1px solid $primary700;
-            color: $primary700;
+            border: 1px solid var(--primary700);
+            color: var(--primary700);
             &:hover, &:active,
             &:focus {
-                border: 1px solid $primary800;
-                color: $primary800;
+                border: 1px solid var(--primary800);
+                color: var(--primary800);
             }
         }
         &.text {
-            color: $primary700;
+            color: var(--primary700);
             &:hover {
-                color: $primary800;
+                color: var(--primary800);
             }
             &:active, &:focus {
-                border: 1px solid $primary800;
-                color: $primary800;
+                border: 1px solid var(--primary800);
+                color: var(--primary800);
             }
         }
     }
 
     &.redColor {
-        background-color: $alert300;
-        color: $neutral100;
+        background-color: var(--alert300);
+        color: var(--neutral100);
         &:hover {
-            background-color: $alert400;
+            background-color: var(--alert400);
         }
         &.outlineChip {
-            border: 1px solid $alert300;
-            color: $alert300;
+            border: 1px solid var(--alert300);
+            color: var(--alert300);
             &:hover, &:active,
             &:focus { 
-                border: 1px solid $alert400;
-                color: $alert400;
+                border: 1px solid var(--alert400);
+                color: var(--alert400);
             }
         }
         &.text {
-            color: $alert300;
+            color: var(--alert300);
             &:hover {
-                color: $alert400;
+                color: var(--alert400);
             }
             &:active, &:focus {
-                border: 1px solid $alert400;
-                color: $alert400;
+                border: 1px solid var(--alert400);
+                color: var(--alert400);
             }
         }
     }
 
     &.greenColor {
-        background-color: $success300;
-        color: $neutral100;
+        background-color: var(--success300);
+        color: var(--neutral100);
         &:hover {
-            background-color: $success400;
+            background-color: var(--success400);
         }
         &.outlineChip {
-            border: 1px solid $success300;
-            color: $success300;
+            border: 1px solid var(--success300);
+            color: var(--success300);
             &:hover, &:active,
             &:focus {
-                border: 1px solid $success400;
-                color: $success400;
+                border: 1px solid var(--success400);
+                color: var(--success400);
             }
         }
         &.text {
-            color: $success300;
+            color: var(--success300);
             &:hover {
-                color: $success400;
+                color: var(--success400);
             }
             &:active,
             &:focus {
-                border: 1px solid $success400;
-                color: $success400;
+                border: 1px solid var(--success400);
+                color: var(--success400);
             }
         }
     }
     &.yellowColor {
-        background-color: $warning300;
-        color: $neutral900;
+        background-color: var(--warning300);
+        color: var(--neutral900);
         &:hover {
-            background-color: $warning400;
-            color: $neutral1000;
+            background-color: var(--warning400);
+            color: var(--neutral1000);
         }
         &.outlineChip {
-            border: 1px solid $warning300;
-            color: $neutral1000;
+            border: 1px solid var(--warning300);
+            color: var(--neutral1000);
             &:hover, &:active,
             &:focus { 
-                border: 1px solid $warning400;
+                border: 1px solid var(--warning400);
             }
         }
         &.text {
-            color: $neutral1000;
+            color: var(--neutral1000);
             &:hover {
-                color: $neutral1000;
+                color: var(--neutral1000);
             }
             &:active,
             &:focus {
-                border: 1px solid $warning400;
-                color: $neutral1000;
+                border: 1px solid var(--warning400);
+                color: var(--neutral1000);
             }
         }
     }
     &.blueColor {
-        background-color: $info300;
-        color: $neutral100;
+        background-color: var(--info300);
+        color: var(--neutral100);
         &:hover {
-            background-color: $info400;
+            background-color: var(--info400);
         }
         &.outlineChip {
             background-color: transparent;
-            border: 1px solid $info300;
-            color: $info300;
+            border: 1px solid var(--info300);
+            color: var(--info300);
             &:hover, &:active,
             &:focus {
-                border: 1px solid $info400;
-                color: $info400;
+                border: 1px solid var(--info400);
+                color: var(--info400);
             }
         }
         &.text {
-            color: $info300;
+            color: var(--info300);
             &:hover {
-                color: $info400;
+                color: var(--info400);
             }
             &:active,
             &:focus {
-                border: 1px solid $info400;
-                color: $info400;
+                border: 1px solid var(--info400);
+                color: var(--info400);
             }
         }
     }
     &.tealColor {
-        background-color: $secondary600;
-        color: $neutral100;
+        background-color: var(--secondary600);
+        color: var(--neutral100);
         &:hover {
-            background-color: $secondary800;
+            background-color: var(--secondary800);
         }
         &.outlineChip {
             background-color: transparent;
-            border: 1px solid $secondary600;
-            color: $secondary600;
+            border: 1px solid var(--secondary600);
+            color: var(--secondary600);
             &:hover, &:active,
             &:focus {
-                border: 1px solid $secondary800;
-                color: $secondary800;
+                border: 1px solid var(--secondary800);
+                color: var(--secondary800);
             }
         }
         &.text {
-            color: $secondary600;
+            color: var(--secondary600);
             &:hover {
-                color: $secondary800;
+                color: var(--secondary800);
             }
             &:active,
             &:focus {
-                border: 1px solid $secondary800;
-                color: $secondary800;
+                border: 1px solid var(--secondary800);
+                color: var(--secondary800);
             }
         }
     }
     &.pinkColor {
-        background-color: $tertiary600;
-        color: $neutral100;
+        background-color: var(--tertiary600);
+        color: var(--neutral100);
         &:hover {
-            background-color: $tertiary800;
+            background-color: var(--tertiary800);
         }
         &.outlineChip {
             background-color: transparent;
-            border: 1px solid $tertiary600;
-            color: $tertiary600;
+            border: 1px solid var(--tertiary600);
+            color: var(--tertiary600);
             &:hover, &:active,
             &:focus {
-                border: 1px solid $tertiary800;
-                color: $tertiary800;
+                border: 1px solid var(--tertiary800);
+                color: var(--tertiary800);
             }
         }
         &.text {
-            color: $tertiary600;
+            color: var(--tertiary600);
             &:hover {
-                color: $tertiary900;
+                color: var(--tertiary900);
             }
             &:active,
             &:focus {
-                border: 1px solid $tertiary900;
-                color: $tertiary900;
+                border: 1px solid var(--tertiary900);
+                color: var(--tertiary900);
             }
         }
     }
 
     &.blackColor {
-        background-color: $neutral1000;
-        color: $neutral100;
+        background-color: var(--neutral1000);
+        color: var(--neutral100);
         &:hover {
-            background-color: $neutral800;
+            background-color: var(--neutral800);
         }
         &.outlineChip {
             background-color: transparent;
-            border: 1px solid $neutral1000;
-            color: $neutral1000;
+            border: 1px solid var(--neutral1000);
+            color: var(--neutral1000);
             &:hover {
-                border: 1px solid $neutral800;
-                color: $neutral800;
+                border: 1px solid var(--neutral800);
+                color: var(--neutral800);
             }
             &:active, &:focus {
-                border: 1px solid $neutral700;
-                color: $primary700;
+                border: 1px solid var(--neutral700);
+                color: var(--primary700);
             }
         }
         &.text {
-            color: $neutral1000;
+            color: var(--neutral1000);
             &:hover {
-                color: $neutral800;
+                color: var(--neutral800);
             }
             &:active,
             &:focus {
-                border: 1px solid $primary700;
-                color: $primary700;
+                border: 1px solid var(--primary700);
+                color: var(--primary700);
             }
         }
     }
     &.greyColor {
-        background-color: $neutral300;
-        color: $neutral700;
+        background-color: var(--neutral300);
+        color: var(--neutral700);
         &:hover {
-            background-color: $neutral400;
+            background-color: var(--neutral400);
         }
         &:active, &:focus {
-            color: $primary700;
+            color: var(--primary700);
         }
         &.outlineChip {
             background-color: transparent;
-            border: 1px solid $neutral400;
-            color: $neutral400;
+            border: 1px solid var(--neutral400);
+            color: var(--neutral400);
             &:hover {
-                border: 1px solid $neutral600;
-                color: $neutral600;
+                border: 1px solid var(--neutral600);
+                color: var(--neutral600);
             }
             &:active, &:focus {
-                color: $primary700;
+                color: var(--primary700);
             }
         }
         &.text {
-            color: $neutral400;
+            color: var(--neutral400);
             &:hover {
-                color: $neutral600;
+                color: var(--neutral600);
             }
             &:active,
             &:focus {
-                border: 1px solid $primary700;
-                color: $primary700;
+                border: 1px solid var(--primary700);
+                color: var(--primary700);
             }
         }
     }

--- a/web/src/templates/page/sections/components/generic/contentHeadingContainer/component/ContentHeadingList.tsx
+++ b/web/src/templates/page/sections/components/generic/contentHeadingContainer/component/ContentHeadingList.tsx
@@ -96,13 +96,19 @@ const ContentHeadingList: React.FC<ISectionProps> = props => {
         return (
           <div id={idContent} key={`content_` + idContent}>
             {titleSize === "small" && (
-              <h4 className={`${cx("heading4 marginBottom32")}`}>{title}</h4>
+              <h4 className={`${cx("heading4 neutral1000 marginBottom32")}`}>
+                {title}
+              </h4>
             )}
             {titleSize === "medium" && (
-              <h3 className={`${cx("heading3 marginBottom32")}`}>{title}</h3>
+              <h3 className={`${cx("heading3 neutral1000 marginBottom32")}`}>
+                {title}
+              </h3>
             )}
             {titleSize === "large" && (
-              <h1 className={`${cx("heading1 marginBottom32")}`}>{title}</h1>
+              <h1 className={`${cx("heading1 neutral1000 marginBottom32")}`}>
+                {title}
+              </h1>
             )}
 
             {content && <MarkDownContent content={content} />}

--- a/web/src/templates/page/sections/components/generic/segmentedButtons/segmentedButtonsContainer.module.scss
+++ b/web/src/templates/page/sections/components/generic/segmentedButtons/segmentedButtonsContainer.module.scss
@@ -15,7 +15,7 @@
         width: fit-content;
         margin: 0 auto;
         height: 48px;
-        background-color: $neutral200;
+        background-color: var(--neutral200);
         padding: 8px;
         border-radius: 12px;
         text-align: center;

--- a/web/src/templates/page/sections/components/generic/selectorList/component/selector.module.scss
+++ b/web/src/templates/page/sections/components/generic/selectorList/component/selector.module.scss
@@ -18,7 +18,7 @@
         position: relative;
         @include flexbox();
         .title {
-            color: $primary700;
+            color: var(--primary700);
             @include min-width($desktopSM) {
                 margin-left: 70px;
             }
@@ -27,7 +27,7 @@
             }
         }
         .notSelected {
-            color: $neutral1000;
+            color: var(--neutral1000);
             cursor: pointer;
             margin-bottom: 20px;
             text-decoration: none;

--- a/web/src/templates/page/sections/components/pricing/pricingInfo/PricingInfo.tsx
+++ b/web/src/templates/page/sections/components/pricing/pricingInfo/PricingInfo.tsx
@@ -5,7 +5,6 @@ import LicensesTableMobile from "./components/licensesTableMobile/LicensesTableM
 import LicensesTable from "./components/licensesTable/LicensesTable"
 import {
   ButtonModel,
-  HeadingModel,
   IProductModel,
 } from "../../../../../../interfaces/interfaces"
 import CrevronDownSVG from "../../../../../../images/icons/ChevronDownSVG"
@@ -19,7 +18,7 @@ import FullWidthCard from "../../shared/fullWidthCard/FullWidthCard"
 export type ISectionProps = {
   switchLabel?: string
   index: number
-  headingOnPremise: HeadingModel
+  headingOnPremise: any
   segmentedButtons: {
     attributes: {
       button: ButtonModel
@@ -113,6 +112,8 @@ const PricingInfo: React.FC<ISectionProps> = props => {
         })
       : null
   }
+
+  const fullWidthCardHeadingData = headingOnPremise?.data?.attributes
 
   return (
     <>
@@ -221,7 +222,9 @@ const PricingInfo: React.FC<ISectionProps> = props => {
             </>
           ) : (
             <>
-              <FullWidthCard color="white" heading={headingOnPremise} />
+              {fullWidthCardHeadingData && (
+                <FullWidthCard heading={headingOnPremise} color="white" />
+              )}
             </>
           )}
         </div>

--- a/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTable/LicensesTable.tsx
+++ b/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTable/LicensesTable.tsx
@@ -54,12 +54,16 @@ const LicensesTable: React.FC<ILicensesTableProps> = props => {
                   >
                     <div className={styles?.table__header__cell__content}>
                       <div>
-                        <p className={`${cx("bodyBoldXL")}`}>{item?.name}</p>
+                        <p className={`${cx("bodyBoldXL neutral1000")}`}>
+                          {item?.name}
+                        </p>
 
                         <div>
                           <p>
-                            <span className={cx("heading4")}>{getPrice()}</span>
-                            <span className={cx("heading4")}>
+                            <span className={cx("heading4 neutral1000")}>
+                              {getPrice()}
+                            </span>
+                            <span className={cx("heading4 neutral1000")}>
                               {(item?.amountYearly || item?.amountMonthly) && (
                                 <span>€</span>
                               )}
@@ -210,14 +214,14 @@ const LicensesTable: React.FC<ILicensesTableProps> = props => {
                     {item?.attributes.features?.dataAgreements === true ? (
                       <td
                         key={"DA__" + Math.random()}
-                        className={`${cx("bodyBoldSM")}`}
+                        className={`${cx("bodyBoldSM neutral1000")}`}
                       >
                         <img src={images.checkIcon}></img>
                       </td>
                     ) : (
                       <td
                         key={"DA__" + Math.random()}
-                        className={`${cx("bodyBoldSM")}`}
+                        className={`${cx("bodyBoldSM neutral1000")}`}
                       >
                         <img src={images.closeIcon}></img>
                       </td>
@@ -241,14 +245,14 @@ const LicensesTable: React.FC<ILicensesTableProps> = props => {
                 return item?.attributes.features?.verifiableIds === true ? (
                   <td
                     key={"Vids__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.checkIcon}></img>
                   </td>
                 ) : (
                   <td
                     key={"Vids__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.closeIcon}></img>
                   </td>
@@ -270,14 +274,14 @@ const LicensesTable: React.FC<ILicensesTableProps> = props => {
                 return item?.attributes.features?.customSchemas === true ? (
                   <td
                     key={"CS__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.checkIcon}></img>
                   </td>
                 ) : (
                   <td
                     key={"CS__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.closeIcon}></img>
                   </td>
@@ -300,14 +304,14 @@ const LicensesTable: React.FC<ILicensesTableProps> = props => {
                   true ? (
                   <td
                     key={"SE__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.checkIcon}></img>
                   </td>
                 ) : (
                   <td
                     key={"SE__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.closeIcon}></img>
                   </td>
@@ -329,14 +333,14 @@ const LicensesTable: React.FC<ILicensesTableProps> = props => {
                 return item?.attributes.features?.extraCredentials === true ? (
                   <td
                     key={"EC__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.checkIcon}></img>
                   </td>
                 ) : (
                   <td
                     key={"EC__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.closeIcon}></img>
                   </td>
@@ -465,14 +469,14 @@ const LicensesTable: React.FC<ILicensesTableProps> = props => {
                   true ? (
                   <td
                     key={"QC__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.checkIcon}></img>
                   </td>
                 ) : (
                   <td
                     key={"QC__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.closeIcon}></img>
                   </td>
@@ -523,14 +527,14 @@ const LicensesTable: React.FC<ILicensesTableProps> = props => {
                 return item?.attributes.features?.statistics === true ? (
                   <td
                     key={"ST__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.checkIcon}></img>
                   </td>
                 ) : (
                   <td
                     key={"ST__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.closeIcon}></img>
                   </td>
@@ -553,14 +557,14 @@ const LicensesTable: React.FC<ILicensesTableProps> = props => {
                   true ? (
                   <td
                     key={"Role__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.checkIcon}></img>
                   </td>
                 ) : (
                   <td
                     key={"Role__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.closeIcon}></img>
                   </td>
@@ -582,14 +586,14 @@ const LicensesTable: React.FC<ILicensesTableProps> = props => {
                 return item?.attributes.features?.customRoles === true ? (
                   <td
                     key={"CR__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.checkIcon}></img>
                   </td>
                 ) : (
                   <td
                     key={"CR__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.closeIcon}></img>
                   </td>
@@ -616,14 +620,14 @@ const LicensesTable: React.FC<ILicensesTableProps> = props => {
                 return item?.attributes.features?.ticketingSystem === true ? (
                   <td
                     key={"TS__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.checkIcon}></img>
                   </td>
                 ) : (
                   <td
                     key={"TS__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.closeIcon}></img>
                   </td>
@@ -645,14 +649,14 @@ const LicensesTable: React.FC<ILicensesTableProps> = props => {
                 return item?.attributes.features?.slackSupport === true ? (
                   <td
                     key={"SS__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.checkIcon}></img>
                   </td>
                 ) : (
                   <td
                     key={"SS__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.closeIcon}></img>
                   </td>
@@ -674,14 +678,14 @@ const LicensesTable: React.FC<ILicensesTableProps> = props => {
                 return item?.attributes.features?.accountTeam === true ? (
                   <td
                     key={"AT__" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.checkIcon}></img>
                   </td>
                 ) : (
                   <td
                     key={"AT" + Math.random()}
-                    className={`${cx("bodyBoldSM")}`}
+                    className={`${cx("bodyBoldSM neutral1000")}`}
                   >
                     <img src={images.closeIcon}></img>
                   </td>

--- a/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTable/elements/cells/category/CategoryCell.tsx
+++ b/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTable/elements/cells/category/CategoryCell.tsx
@@ -11,7 +11,7 @@ const CategoryCell: React.FC<ICategoryCellProps> = props => {
   const { category, rowsPan } = props
   return (
     <td
-      className={`${styles?.categoryCell} ${cx("bodyBoldCap")}`}
+      className={`${styles?.categoryCell} ${cx("bodyBoldCap neutral1000")}`}
       rowSpan={rowsPan}
     >
       {category}

--- a/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTable/elements/cells/iconDataCell/IconDataCell.tsx
+++ b/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTable/elements/cells/iconDataCell/IconDataCell.tsx
@@ -11,7 +11,7 @@ const IconDataCell: React.FC<IIconDataCellProps> = props => {
   const { data } = props
   return (
     <>
-      <td className={`${cx("bodyBoldSM")}`}>
+      <td className={`${cx("bodyBoldSM neutral1000")}`}>
         <img
           className={styles?.icon}
           src={data ? images.checkIcon : images.closeIcon}

--- a/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTable/elements/cells/listDataCell/ListDataCell.tsx
+++ b/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTable/elements/cells/listDataCell/ListDataCell.tsx
@@ -8,8 +8,8 @@ export type IListDataCellProps = {
 const ListDataCell: React.FC<IListDataCellProps> = props => {
   let { data } = props
 
-  if(typeof data === 'string') {
-    data = data.split(',');
+  if (typeof data === "string") {
+    data = data.split(",")
   }
   const isLastItem = (itemsArray: any[], item: any) => {
     const arrLength = itemsArray?.length
@@ -19,16 +19,19 @@ const ListDataCell: React.FC<IListDataCellProps> = props => {
 
   return (
     <>
-      <td className={`${cx("bodyBoldSM")}`}>
+      <td className={`${cx("bodyBoldSM neutral1000")}`}>
         {data?.length ? (
           data?.map((el: string, index: number) => (
-            <p key={"dataC__" + index} className={`${cx("bodyBoldSM")}`}>
+            <p
+              key={"dataC__" + index}
+              className={`${cx("bodyBoldSM neutral1000")}`}
+            >
               {el}
               {!isLastItem(data, el) ? "," : ""}
             </p>
           ))
         ) : (
-          <p className={`${cx("bodyBoldSM")}`}>None</p>
+          <p className={`${cx("bodyBoldSM neutral1000")}`}>None</p>
         )}
       </td>
     </>

--- a/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTable/elements/cells/quantityDataCell/QuantityDataCell.tsx
+++ b/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTable/elements/cells/quantityDataCell/QuantityDataCell.tsx
@@ -9,7 +9,7 @@ const QuantityDataCell: React.FC<IQuantityDataCellProps> = props => {
   const { data } = props
   return (
     <>
-      <td className={`${cx("bodyBoldSM")}`}>
+      <td className={`${cx("bodyBoldSM neutral1000")}`}>
         {data === "∞" || data === -1
           ? "Unlimited"
           : data === -2

--- a/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTable/elements/cells/subcategoryCell/SubcategoryCell.tsx
+++ b/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTable/elements/cells/subcategoryCell/SubcategoryCell.tsx
@@ -12,9 +12,13 @@ export type ISubcategoryCellProps = {
 const SubcategoryCell: React.FC<ISubcategoryCellProps> = props => {
   const { subcategory, information } = props
   return (
-    <td className={`${styles?.subcategoryCell} ${cx("bodyRegularSM")}`}>
+    <td
+      className={`${styles?.subcategoryCell} ${cx(
+        "bodyRegularSM neutral1000"
+      )}`}
+    >
       <span>
-        <p className={`${cx("bodyRegularSM")}`}>{subcategory}</p>
+        <p className={`${cx("bodyRegularSM neutral1000")}`}>{subcategory}</p>
         {information?.length && information?.length > 0 ? (
           <HoverTooltip label={information} />
         ) : null}

--- a/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTable/licensesTable.module.scss
+++ b/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTable/licensesTable.module.scss
@@ -32,7 +32,7 @@ table {
     left: 0;
     box-shadow: 0px 4px 8px 0px #0000001F;
     z-index: -1;
-    background-color: $neutral100;
+    background-color: var(--neutral100);
   }
 }
 
@@ -121,9 +121,9 @@ table {
       }
     }
     &__row {
-        background-color: $neutral100;
+        background-color: var(--neutral100);
       & > td {
-      border: 1px solid $neutral300;
+      border: 1px solid var(--neutral300);
       padding: 12px;
       line-height: 16px;
     }

--- a/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTableMobile/LicensesTableMobile.tsx
+++ b/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTableMobile/LicensesTableMobile.tsx
@@ -64,11 +64,11 @@ const LicensesTableMobile: React.FC<ILicensesTableMobileProps> = props => {
     <>
       <div className={styles?.tableContainer}>
         <div>
-          <p className={`${cx("heading4")}`} id={"featuresTable"}>
+          <p className={`${cx("heading4 neutral1000")}`} id={"featuresTable"}>
             {titleFeaturesTableMobile}
           </p>
           <select
-            className={`${styles?.selector} ${cx("bodyRegularMD")}`}
+            className={`${styles?.selector} ${cx("bodyRegularMD neutral1000")}`}
             defaultValue={licenseIndex || 0}
             onChange={event => {
               selectLicense(event?.target?.value)
@@ -79,7 +79,7 @@ const LicensesTableMobile: React.FC<ILicensesTableMobileProps> = props => {
                 <option
                   key={"pricingOption__" + index}
                   defaultChecked={licenseIndex === index + 1}
-                  className={`${cx("bodyRegularMD")}`}
+                  className={`${cx("bodyRegularMD neutral1000")}`}
                   value={index}
                 >
                   {item?.name}
@@ -89,7 +89,7 @@ const LicensesTableMobile: React.FC<ILicensesTableMobileProps> = props => {
           </select>
           <div className={styles?.header__container}>
             <div>
-              <p className={cx("heading3")}>
+              <p className={cx("heading3 neutral1000")}>
                 <span>{getPrice(pricingSelected)}</span>
                 <span>
                   {(pricingSelected?.amountYearly ||
@@ -134,7 +134,7 @@ const LicensesTableMobile: React.FC<ILicensesTableMobileProps> = props => {
                   ?.infoToggle
               }
             />
-            <div className={`${cx("bodyBoldSM")}`}>
+            <div className={`${cx("bodyBoldSM neutral1000")}`}>
               <QuantityDataCell
                 data={
                   getGatacaTiersLicense()?.attributes?.features
@@ -154,7 +154,7 @@ const LicensesTableMobile: React.FC<ILicensesTableMobileProps> = props => {
                   ?.infoToggle
               }
             />
-            <div className={`${cx("bodyBoldSM")}`}>
+            <div className={`${cx("bodyBoldSM neutral1000")}`}>
               <QuantityDataCell
                 data={
                   getGatacaTiersLicense()?.attributes?.features
@@ -174,7 +174,7 @@ const LicensesTableMobile: React.FC<ILicensesTableMobileProps> = props => {
                   ?.infoToggle
               }
             />
-            <div className={`${cx("bodyBoldSM")}`}>
+            <div className={`${cx("bodyBoldSM neutral1000")}`}>
               <QuantityDataCell
                 data={
                   getGatacaTiersLicense()?.attributes?.features?.activeUsers
@@ -193,7 +193,7 @@ const LicensesTableMobile: React.FC<ILicensesTableMobileProps> = props => {
                   ?.infoToggle
               }
             />
-            <div className={`${cx("bodyBoldSM")}`}>
+            <div className={`${cx("bodyBoldSM neutral1000")}`}>
               <QuantityDataCell
                 data={
                   getGatacaTiersLicense()?.attributes?.features
@@ -310,7 +310,7 @@ const LicensesTableMobile: React.FC<ILicensesTableMobileProps> = props => {
                   ?.infoToggle
               }
             />
-            <div className={`${cx("bodyBoldSM")}`}>
+            <div className={`${cx("bodyBoldSM neutral1000")}`}>
               <td className={styles.markdown}>
                 {getGatacaTiersLicense()?.attributes.features?.ageVerification
                   ?.length && (
@@ -335,7 +335,7 @@ const LicensesTableMobile: React.FC<ILicensesTableMobileProps> = props => {
                   ?.infoToggle
               }
             />
-            <div className={`${cx("bodyBoldSM")}`}>
+            <div className={`${cx("bodyBoldSM neutral1000")}`}>
               <td className={styles.markdown}>
                 {getGatacaTiersLicense()?.attributes.features?.appIntegrations
                   ?.length && (
@@ -365,7 +365,7 @@ const LicensesTableMobile: React.FC<ILicensesTableMobileProps> = props => {
                   ?.infoToggle
               }
             />
-            <div className={`${cx("bodyBoldSM")}`}>
+            <div className={`${cx("bodyBoldSM neutral1000")}`}>
               <td className={styles.markdown}>
                 {getGatacaTiersLicense()?.attributes.features?.didMethods
                   ?.length && (
@@ -389,7 +389,7 @@ const LicensesTableMobile: React.FC<ILicensesTableMobileProps> = props => {
                   ?.infoToggle
               }
             />
-            <div className={`${cx("bodyBoldSM")}`}>
+            <div className={`${cx("bodyBoldSM neutral1000")}`}>
               <td className={styles.markdown}>
                 {getGatacaTiersLicense()?.attributes.features?.trustRegistries
                   ?.length && (
@@ -432,7 +432,7 @@ const LicensesTableMobile: React.FC<ILicensesTableMobileProps> = props => {
                   ?.infoToggle
               }
             />
-            <div className={`${cx("bodyBoldSM")}`}>
+            <div className={`${cx("bodyBoldSM neutral1000")}`}>
               <td className={styles.markdown}>
                 {getGatacaTiersLicense()?.attributes.features?.enterpriseWallet
                   ?.length && (
@@ -560,7 +560,7 @@ const LicensesTableMobile: React.FC<ILicensesTableMobileProps> = props => {
                   ?.infoToggle
               }
             />
-            <div className={`${cx("bodyBoldSM")}`}>
+            <div className={`${cx("bodyBoldSM neutral1000")}`}>
               <td className={styles.markdown}>
                 {getGatacaTiersLicense()?.attributes.features?.twentyFourSeven
                   ?.length && (
@@ -585,7 +585,7 @@ const LicensesTableMobile: React.FC<ILicensesTableMobileProps> = props => {
                   ?.infoToggle
               }
             />
-            <div className={`${cx("bodyBoldSM")}`}>
+            <div className={`${cx("bodyBoldSM neutral1000")}`}>
               <td className={styles.markdown}>
                 {getGatacaTiersLicense()?.attributes.features?.slas?.length && (
                   <MarkDownContent
@@ -606,7 +606,7 @@ const LicensesTableMobile: React.FC<ILicensesTableMobileProps> = props => {
                   ?.infoToggle
               }
             />
-            <div className={`${cx("bodyBoldSM")}`}>
+            <div className={`${cx("bodyBoldSM neutral1000")}`}>
               <td className={styles.markdown}>
                 {getGatacaTiersLicense()?.attributes.features
                   ?.onboardingTraining?.length && (

--- a/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTableMobile/elements/cardHeader/CardHeader.tsx
+++ b/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTableMobile/elements/cardHeader/CardHeader.tsx
@@ -10,7 +10,7 @@ export const CardHeader: React.FC<ICardHeaderProps> = props => {
   const { title } = props
   return (
     <div key={0} className={styles?.card__header}>
-      <p className={`${cx("bodyBoldLG")}`}>{title}</p>
+      <p className={`${cx("bodyBoldLG neutral1000")}`}>{title}</p>
     </div>
   )
 }

--- a/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTableMobile/elements/cardHeader/cardHeader.module.scss
+++ b/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTableMobile/elements/cardHeader/cardHeader.module.scss
@@ -3,5 +3,5 @@
 
 .card__header {
     padding: 12px 20px;
-    border-bottom: 1px solid $neutral300;
+    border-bottom: 1px solid var(--neutral300);
 }

--- a/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTableMobile/elements/cardLeftColumn/CardLeftColumn.tsx
+++ b/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTableMobile/elements/cardLeftColumn/CardLeftColumn.tsx
@@ -14,7 +14,7 @@ export const CardLeftColumn: React.FC<ICardLeftColumnProps> = props => {
   return (
     <div key={0} className={styles?.card__row}>
       <div>
-        <p className={`${cx("bodyRegularSM")}`}>{text}</p>
+        <p className={`${cx("bodyRegularSM neutral1000")}`}>{text}</p>
         {information?.length && information?.length > 0 ? (
           <HoverTooltip label={information} />
         ) : null}

--- a/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTableMobile/elements/cells/listDataCell/ListDataCell.tsx
+++ b/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTableMobile/elements/cells/listDataCell/ListDataCell.tsx
@@ -19,10 +19,13 @@ const ListDataCell: React.FC<IListDataCellProps> = props => {
   }
 
   return (
-    <div className={`${cx("bodyBoldSM")}`}>
+    <div className={`${cx("bodyBoldSM neutral1000")}`}>
       {data?.length ? (
         data?.map((el: string, index: number) => (
-          <p key={"dataCM__" + index} className={`${cx("bodyBoldSM")}`}>
+          <p
+            key={"dataCM__" + index}
+            className={`${cx("bodyBoldSM neutral1000")}`}
+          >
             {el}
             {!isLastItem(data, el) ? "," : ""}
           </p>

--- a/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTableMobile/elements/cells/quantityDataCell/QuantityDataCell.tsx
+++ b/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTableMobile/elements/cells/quantityDataCell/QuantityDataCell.tsx
@@ -8,8 +8,10 @@ export type IQuantityDataCellProps = {
 const QuantityDataCell: React.FC<IQuantityDataCellProps> = props => {
   const { data } = props
   return (
-    <div className={`${cx("bodyBoldSM")}`}>
-      {(data === "∞" || data === -1) ? "Unlimited" : new Intl.NumberFormat('en-DE').format(data)}
+    <div className={`${cx("bodyBoldSM neutral1000")}`}>
+      {data === "∞" || data === -1
+        ? "Unlimited"
+        : new Intl.NumberFormat("en-DE").format(data)}
     </div>
   )
 }

--- a/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTableMobile/licensesTableMobile.module.scss
+++ b/web/src/templates/page/sections/components/pricing/pricingInfo/components/licensesTableMobile/licensesTableMobile.module.scss
@@ -22,13 +22,13 @@
   margin-top: 32px;
   width: 100%;
   border-radius: 12px;
-  border: 1px solid $neutral300;
+  border: 1px solid var(--neutral300);
   overflow: hidden;
-  background-color: $neutral100;
+  background-color: var(--neutral100);
 
   & > .card__header {
     padding: 12px 20px;
-    border-bottom: 1px solid $neutral300;
+    border-bottom: 1px solid var(--neutral300);
   }
 
   & > .card__row {
@@ -36,7 +36,7 @@
     
     & > div:nth-child(1) {
       padding: 12px;
-      border-right: 1px solid $neutral300;
+      border-right: 1px solid var(--neutral300);
       min-width: 140px;
       width: 140px;
       @include min-width($mobileXL) {
@@ -60,7 +60,7 @@
   }
 
   & > .card__row:not(:last-child) {
-    border-bottom: 1px solid $neutral300;
+    border-bottom: 1px solid var(--neutral300);
   }
 
   .icon {
@@ -88,14 +88,14 @@
 }
 
 .popularTag {
-  background-color: $primary700;
+  background-color: var(--primary700);
   border-radius: 5px;
   padding: 3px 8px;
   width: fit-content;
   margin-left: auto;
   height: 18px;
   & > p {
-    color: $neutral100;
+    color: var(--neutral100);
     font-weight: 400;
     font-size: 12px;
   }
@@ -105,9 +105,9 @@
   width: 100%;
   padding: 8px 12px;
   height: 40px;
-  border: 1px solid $neutral400;
+  border: 1px solid var(--neutral400);
   border-radius: 8px;
-  background-color: $neutral100;
+  background-color: var(--neutral100);
 }
 
 select {

--- a/web/src/templates/page/sections/components/pricing/pricingInfo/pricingInfo.module.scss
+++ b/web/src/templates/page/sections/components/pricing/pricingInfo/pricingInfo.module.scss
@@ -36,7 +36,7 @@
     }
 
     p {
-      color: $neutral700;
+      color: var(--neutral700);
       margin-bottom: 80px;
 
       @include min-width($mobileXL) {
@@ -53,7 +53,7 @@
       max-width: 260px;
       margin: 0 auto;
       height: 48px;
-      background-color: $neutral200;
+      background-color: var(--neutral200);
       padding: 8px;
       border-radius: 12px;
       text-align: center;

--- a/web/src/templates/page/sections/components/shared/FormLayout/components/formSkeleton.module.scss
+++ b/web/src/templates/page/sections/components/shared/FormLayout/components/formSkeleton.module.scss
@@ -33,7 +33,7 @@
   }
   .skeleton {
     width: 100%;
-    background: $skeletonBG;
+    background: var(--skeletonBG);
     height: 64px;
     border-radius: 8px;
     margin-bottom: 18px;
@@ -148,7 +148,7 @@
   display: block;
   width: 128px;
   height: 871px;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0), $neutral100, rgba(255, 255, 255, 0));
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0), var(--neutral100), rgba(255, 255, 255, 0));
   content: "";
   animation: skeleton-animation 2s infinite;
   @include min-width($mobileXL) {

--- a/web/src/templates/page/sections/components/shared/FormLayout/formLayout.module.scss
+++ b/web/src/templates/page/sections/components/shared/FormLayout/formLayout.module.scss
@@ -78,12 +78,12 @@
         &.background {
           &.greyBackground {
             &::before {
-              background-color: $neutral200;
+              background-color: var(--neutral200);
             }
           }
           &.blackBackground {
             &::before {
-              background-color: $neutral1000;
+              background-color: var(--neutral1000);
             }
           }
         }
@@ -108,10 +108,10 @@
           }
         }
         .form__container {
-          background-color: $neutral100;
+          background-color: var(--neutral100);
           padding: 20px 20px 4px;
           border-radius: 12px;
-          box-shadow: 0px 0px 10px $boxShadowLigh;
+          box-shadow: 0px 0px 10px var(--boxShadowLigh);
           @include flexbox();
           @include flex-direction(column);
           @include justify-content(center);

--- a/web/src/templates/page/sections/components/shared/Heading/components/formSkeleton.module.scss
+++ b/web/src/templates/page/sections/components/shared/Heading/components/formSkeleton.module.scss
@@ -4,21 +4,21 @@
 .formSkeleton {
     & > div:nth-child(1) {
         width: 294px;
-        background: $skeletonBG;
+        background: var(--skeletonBG);
         height: 23px;
         border-radius: 3px;
     }
     & > div:nth-child(2) {
         width: 100%;
         margin-top: 4px;
-        background: $skeletonBG;
+        background: var(--skeletonBG);
         height: 40px;
         border-radius: 3px;
         margin-bottom: 18px;
     }
     & > div:nth-child(3) {
         width: 90%;
-        background: $skeletonBG;
+        background: var(--skeletonBG);
         height: 23px;
         border-radius: 3px;
         margin-bottom: 35px;
@@ -26,7 +26,7 @@
      & > div:nth-child(4) {
         width: 140px;
         margin: auto auto 17px;
-        background: $skeletonBG;
+        background: var(--skeletonBG);
         height: 42px;
         border-radius: 3px;
         margin-bottom: 17px;
@@ -116,7 +116,7 @@
     display: block;
     width: 128px;
     height: 393px;
-    background: linear-gradient(90deg, rgba(255, 255, 255, 0), $neutral100, rgba(255, 255, 255, 0));
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0), var(--neutral100), rgba(255, 255, 255, 0));
     content: "";
     animation: skeleton-animation 2s infinite;
     @include min-width($mobileXL) {

--- a/web/src/templates/page/sections/components/shared/Heading/heading.module.scss
+++ b/web/src/templates/page/sections/components/shared/Heading/heading.module.scss
@@ -34,7 +34,7 @@
     h1, h3, h4 {
       p {
         font-family: $custom;
-        color: $neutral1000;
+        color: var(--neutral1000);
         margin-bottom: 0;
         text-decoration: none;
         font-weight: 700;
@@ -60,7 +60,7 @@
     }
     .heading__content {
       p {
-        color: $neutral700;
+        color: var(--neutral700);
         font-family: $base;
           font-size: 20px;
           font-weight: 400;
@@ -85,11 +85,11 @@
       padding: 0;
     }
     .form__container {
-      background-color: $neutral100;
+      background-color: var(--neutral100);
       padding: 20px 20px 4px;
       margin-top: 32px;
       border-radius: 12px;
-      box-shadow: 0px 0px 10px $boxShadowLigh;
+      box-shadow: 0px 0px 10px var(--boxShadowLigh);
       @include flexbox();
       @include flex-direction(column);
       @include justify-content(space-between);

--- a/web/src/templates/page/sections/components/shared/Highlight/highlight.module.scss
+++ b/web/src/templates/page/sections/components/shared/Highlight/highlight.module.scss
@@ -3,23 +3,23 @@
 
 .highlight {
   &.blackBackground {
-    background-color: $neutral1000;
+    background-color: var(--neutral1000);
     & > div > div > div {
       & > h1, h3, h4 {
         p {
-          color: $neutral100;
+          color: var(--neutral100);
         }
       }
       & > h6 {
-        color: $neutral100;
+        color: var(--neutral100);
       }
       & > div > div > p {
-        color: $neutral400;
+        color: var(--neutral400);
       }
     }
   }
   &.greyBackground {
-    background-color: $neutral200;
+    background-color: var(--neutral200);
   }
   .alignCenter {
     padding: 100px 20px;

--- a/web/src/templates/page/sections/components/shared/HighlightSubHeadingCard/highlightSubHeadingCard.module.scss
+++ b/web/src/templates/page/sections/components/shared/HighlightSubHeadingCard/highlightSubHeadingCard.module.scss
@@ -31,7 +31,7 @@
     }
   }
   &__subHeading {
-    background-color: $neutral100;
+    background-color: var(--neutral100);
     border-radius: 20px;
     box-shadow: 0px 0px 20px 0px rgba(12, 11, 51, 0.12);
     padding: 40px;

--- a/web/src/templates/page/sections/components/shared/LogoContainer/component/Logo.tsx
+++ b/web/src/templates/page/sections/components/shared/LogoContainer/component/Logo.tsx
@@ -23,7 +23,7 @@ const LogoComponent: React.FC<ILogoProps> = props => {
           <StrapiImage image={image ? image : null} />{" "}
         </div>
       ) : null}
-      {title?.length && <p className={cx("bodyBoldLG")}>{title}</p>}
+      {title?.length && <p className={cx("bodyBoldLG neutral1000")}>{title}</p>}
     </div>
   )
 }

--- a/web/src/templates/page/sections/components/shared/LogosComponent/logosComponent.module.scss
+++ b/web/src/templates/page/sections/components/shared/LogosComponent/logosComponent.module.scss
@@ -17,7 +17,7 @@
     padding: 0 60px;
   }
   &.backgroundDark {
-    background-color: $neutral1000;
+    background-color: var(--neutral1000);
     border-radius: 40px;
     padding: 80px 20px;
     @include min-width($mobileXL) {
@@ -28,7 +28,7 @@
     }
 
     > h1, h3, h4, h6, p {
-      color: $neutral100;
+      color: var(--neutral100);
     }
   }
 }

--- a/web/src/templates/page/sections/components/shared/PricingCard/PricingCard.tsx
+++ b/web/src/templates/page/sections/components/shared/PricingCard/PricingCard.tsx
@@ -25,8 +25,8 @@ const PricingCard: React.FC<PricingCardModel> = props => {
   } = props
 
   const titleAmountSizeStyles: Record<string, string> = {
-    medium: "heading4",
-    large: "heading3",
+    medium: "heading4 neutral1000",
+    large: "heading3 neutral1000",
   }
 
   const periodYear = period === "year"
@@ -49,7 +49,7 @@ const PricingCard: React.FC<PricingCardModel> = props => {
       className={`${styles?.pricingCard} ${className && className}`}
     >
       <div>
-        {name && <p className={`${cx("bodyBoldXL")}`}>{name}</p>}
+        {name && <p className={`${cx("bodyBoldXL neutral1000")}`}>{name}</p>}
         {description && (
           <p className={`${cx("marginTop8 bodyRegularMD neutral700")}`}>
             {description}
@@ -67,7 +67,7 @@ const PricingCard: React.FC<PricingCardModel> = props => {
             className={`${
               titleAmountSize
                 ? titleAmountSizeStyles[titleAmountSize]
-                : "heading3"
+                : "heading3 neutral1000"
             }`}
           >
             {getPrice()}
@@ -76,7 +76,7 @@ const PricingCard: React.FC<PricingCardModel> = props => {
             className={`${
               titleAmountSize
                 ? titleAmountSizeStyles[titleAmountSize]
-                : "heading3"
+                : "heading3 neutral1000"
             }`}
           >
             {(amountYearly || amountMonthly) && <span>€</span>}

--- a/web/src/templates/page/sections/components/shared/PricingCard/pricingCard.module.scss
+++ b/web/src/templates/page/sections/components/shared/PricingCard/pricingCard.module.scss
@@ -9,11 +9,11 @@
   @include align-items(flex-start);
   gap: 24px;
   padding: 24px;
-  background-color: $neutral100;
+  background-color: var(--neutral100);
   border-radius: 12px;
   box-shadow: 0px 0px 12px 0px rgba(12, 11, 51, 0.12);
   &__price {
-    border-bottom: 1px solid $neutral300;
+    border-bottom: 1px solid var(--neutral300);
     width: 100%;
     p:last-child {
       margin-bottom: 24px;

--- a/web/src/templates/page/sections/components/shared/actionCard/component/ActionCard.tsx
+++ b/web/src/templates/page/sections/components/shared/actionCard/component/ActionCard.tsx
@@ -34,7 +34,7 @@ const ActionCard: React.FC<ActionCardModel> = props => {
             onClick={() => !selected && showItem(index)}
           >
             {titleCard?.length && (
-              <p className={cx("bodyBoldXL")}>{titleCard}</p>
+              <p className={cx("bodyBoldXL neutral1000")}>{titleCard}</p>
             )}
             {selected ? (
               <>
@@ -67,7 +67,7 @@ const ActionCard: React.FC<ActionCardModel> = props => {
               onClick={() => showItem(!selected ? index : 0)}
             >
               {titleCard?.length && (
-                <p className={cx("bodyBoldXL")}>{titleCard}</p>
+                <p className={cx("bodyBoldXL neutral1000")}>{titleCard}</p>
               )}
               {selected ? (
                 <>
@@ -110,7 +110,7 @@ const ActionCard: React.FC<ActionCardModel> = props => {
                 </div>
               )}
               {titleContent?.length && (
-                <h4 className={cx("bodyBoldXL")}>{titleContent}</h4>
+                <h4 className={cx("bodyBoldXL neutral1000")}>{titleContent}</h4>
               )}
               {content?.length && <MarkDownContent content={content} />}
             </div>

--- a/web/src/templates/page/sections/components/shared/actionCard/component/actionCard.module.scss
+++ b/web/src/templates/page/sections/components/shared/actionCard/component/actionCard.module.scss
@@ -5,7 +5,7 @@
 .actionCard {
   &__container {
     padding: 20px;
-    background-color: $neutral100;
+    background-color: var(--neutral100);
     border-radius: 8px;
     box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, 0.12);
     @include flexbox();

--- a/web/src/templates/page/sections/components/shared/blogCard/BlogCard.tsx
+++ b/web/src/templates/page/sections/components/shared/blogCard/BlogCard.tsx
@@ -54,9 +54,11 @@ const BlogCard: React.FC<BlogPreviewModel> = props => {
       ) : null}
       <div className={styles?.content__container}>
         <div>
-          {title?.length && <h5 className={cx("heading5")}>{title}</h5>}
+          {title?.length && (
+            <h5 className={cx("heading5 neutral1000")}>{title}</h5>
+          )}
           {date?.length && (
-            <p className={cx("bodyRegularMD marginTop8")}>
+            <p className={cx("bodyRegularMD marginTop8 neutral1000")}>
               {moment(date).format("LL")}
             </p>
           )}

--- a/web/src/templates/page/sections/components/shared/blogCard/blogCard.module.scss
+++ b/web/src/templates/page/sections/components/shared/blogCard/blogCard.module.scss
@@ -10,7 +10,7 @@
   @include align-items(flex-start);
   gap: 20px;
   padding: 24px;
-  background-color: $neutral100;
+  background-color: var(--neutral100);
   border-radius: 12px;
   box-shadow: 0px 0px 12px 0px rgba(12, 11, 51, 0.12);
   .chip_extraText__container {

--- a/web/src/templates/page/sections/components/shared/card/Card.tsx
+++ b/web/src/templates/page/sections/components/shared/card/Card.tsx
@@ -33,9 +33,9 @@ const CardComponent: React.FC<CardModel> = props => {
   }
 
   const titleSizeStyles: Record<string, string> = {
-    small: "heading6",
-    medium: "heading5",
-    large: "heading4",
+    small: "heading6 neutral1000",
+    medium: "heading5 neutral1000",
+    large: "heading4 neutral1000",
   }
 
   const contentSizeStyles: Record<string, string> = {
@@ -99,7 +99,11 @@ const CardComponent: React.FC<CardModel> = props => {
             />
           ) : null}
           {title?.length && (
-            <h4 className={cx(size ? titleSizeStyles[size] : "heading4")}>
+            <h4
+              className={cx(
+                size ? titleSizeStyles[size] : "heading4 neutral1000"
+              )}
+            >
               {title}
             </h4>
           )}

--- a/web/src/templates/page/sections/components/shared/card/card.module.scss
+++ b/web/src/templates/page/sections/components/shared/card/card.module.scss
@@ -10,7 +10,7 @@
   @include align-items(flex-start);
   gap: 8px;
   padding: 32px;
-  background-color: $neutral100;
+  background-color: var(--neutral100);
   border-radius: 20px;
   box-shadow: 0px 0px 12px 0px rgba(12, 11, 51, 0.12);
   &.smallSize {
@@ -25,10 +25,10 @@
     }
   }
   .numberIconText {
-    color: $primary200;
+    color: var(--primary200);
   }
   &.showBackContent {
-    background-color: $neutral200;
+    background-color: var(--neutral200);
   }
   &.backContentToShow {
     cursor: pointer;
@@ -63,9 +63,9 @@
       top: 0;
       height: 100%;
       width: 100%;
-      background-color: $neutral200;
+      background-color: var(--neutral200);
       p {
-        color: $neutral1000;
+        color: var(--neutral1000);
       }
     } 
   }

--- a/web/src/templates/page/sections/components/shared/carrouselLogos/carrouselLogos.module.scss
+++ b/web/src/templates/page/sections/components/shared/carrouselLogos/carrouselLogos.module.scss
@@ -9,10 +9,10 @@
     }
   }
   &.lightBackground {
-    background-color: $neutral200;
+    background-color: var(--neutral200);
   }
   &.darkBackground {
-    background-color: $neutral1000;
+    background-color: var(--neutral1000);
   }
   .clientsLogo {
     max-width: 100vw;

--- a/web/src/templates/page/sections/components/shared/contentTable/elements/highlightCard/HighlightCard.tsx
+++ b/web/src/templates/page/sections/components/shared/contentTable/elements/highlightCard/HighlightCard.tsx
@@ -19,7 +19,7 @@ const HighlightCard: React.FC<IHighlightCardProps> = props => {
         className && className
       }`}
     >
-      <p className={cx("bodyBoldLG  neutral1000")}>{title}</p>
+      <p className={cx("bodyBoldLG neutral1000")}>{title}</p>
       <ListGroup listOptions={list_options?.data} />
     </div>
   )

--- a/web/src/templates/page/sections/components/shared/contentTable/elements/highlightCard/highlightCard.module.scss
+++ b/web/src/templates/page/sections/components/shared/contentTable/elements/highlightCard/highlightCard.module.scss
@@ -5,7 +5,7 @@ $cardPadding: 32px;
 
 .highlightCard__container {
   padding: $cardPadding;
-  background-color: $neutral100;
+  background-color: var(--neutral100);
   box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, 0.12);
   border-radius: 12px;
   @include flexbox();

--- a/web/src/templates/page/sections/components/shared/contentTable/elements/tableOfContentContainer/tableOfContentContainer.module.scss
+++ b/web/src/templates/page/sections/components/shared/contentTable/elements/tableOfContentContainer/tableOfContentContainer.module.scss
@@ -12,7 +12,7 @@
   }
   > div {
     padding: 12px 20px;
-    background-color: $neutral200;
+    background-color: var(--neutral200);
     margin-top: -46px;
     @include min-width($tabletMD) {
       border-radius: 12px;
@@ -27,7 +27,7 @@
       @include align-items(center);
       width: 100%;
       span {
-        color: $neutral1000;
+        color: var(--neutral1000);
         font-family: "Poppins";
         font-size: 18px;
         font-weight: 700;

--- a/web/src/templates/page/sections/components/shared/contentTable/elements/tableOfContentOptions/TableOfContentOptions.tsx
+++ b/web/src/templates/page/sections/components/shared/contentTable/elements/tableOfContentOptions/TableOfContentOptions.tsx
@@ -24,7 +24,10 @@ const TableOfContentOptions: React.FC<ITableOfContenOptionProps> = props => {
         const routePath = "#" + idContent
 
         return (
-          <li className={cx("buttonSM")} key={"tableOfContent__" + index}>
+          <li
+            className={cx("buttonSM neutral1000")}
+            key={"tableOfContent__" + index}
+          >
             <Link to={routePath || ""}>{title}</Link>
           </li>
         )

--- a/web/src/templates/page/sections/components/shared/credential/credential.module.scss
+++ b/web/src/templates/page/sections/components/shared/credential/credential.module.scss
@@ -13,49 +13,49 @@
   height: calc(100% - 40px);
   box-shadow: 0px 0px 3.231px 0px rgba(14, 14, 54, 0.16);
   > * {
-    color: $neutral100;
+    color: var(--neutral100);
   }
   &.white {
-    background-color: $neutral100;
+    background-color: var(--neutral100);
     > * {
-      color: $neutral1000;
+      color: var(--neutral1000);
     }
   }
   &.purpleGradient {
-    background: $primaryGradient;
+    background: var(--primaryGradient);
   }
   &.tealGradient {
-    background: $tealGradient;
+    background: var(--tealGradient);
   }
   &.pinkGradient {
-    background: $tertiaryGradient;
+    background: var(--tertiaryGradient);
   }
   &.teal {
-    background-color: $secondary600;
+    background-color: var(--secondary600);
   }
   &.blue {
-    background-color: $info400;
+    background-color: var(--info400);
   }
   &.yellow {
-    background-color: $warning300;
+    background-color: var(--warning300);
     > * {
-      color: $neutral1000;
+      color: var(--neutral1000);
     }
   }
   &.grey {
-    background-color: $neutral700;
+    background-color: var(--neutral700);
   }
   &.green {
-    background-color: $success400;
+    background-color: var(--success400);
   }
   &.darkBlue {
-    background-color: $info500;
+    background-color: var(--info500);
   }
   &.orange {
-    background-color: $orange;
+    background-color: var(--orange);
   }
   &.pink {
-    background-color: $tertiary600;
+    background-color: var(--tertiary600);
   }
   .header__container {
     @include flexbox();
@@ -112,7 +112,7 @@
       @include align-items(center);
       gap: 8px;
       span {
-        color: $neutral700;
+        color: var(--neutral700);
       }
     }
   }

--- a/web/src/templates/page/sections/components/shared/dynamicCard/DynamicCard.tsx
+++ b/web/src/templates/page/sections/components/shared/dynamicCard/DynamicCard.tsx
@@ -24,9 +24,9 @@ const DynamicCard: React.FC<ISectionProps> = props => {
   }
 
   const titleSizeStyles: Record<string, string> = {
-    small: "heading6",
-    medium: "heading5",
-    large: "heading4",
+    small: "heading6 neutral1000",
+    medium: "heading5 neutral1000",
+    large: "heading4 neutral1000",
   }
 
   const contentSizeStyles: Record<string, string> = {
@@ -133,7 +133,11 @@ const DynamicCard: React.FC<ISectionProps> = props => {
               />
             ) : null}
             {title?.length && (
-              <h4 className={cx(size ? titleSizeStyles[size] : "heading4")}>
+              <h4
+                className={cx(
+                  size ? titleSizeStyles[size] : "heading4 neutral1000"
+                )}
+              >
                 {title}
               </h4>
             )}

--- a/web/src/templates/page/sections/components/shared/dynamicCard/dynamicCard.module.scss
+++ b/web/src/templates/page/sections/components/shared/dynamicCard/dynamicCard.module.scss
@@ -10,7 +10,7 @@
   @include align-items(flex-start);
   gap: 8px;
   padding: 32px;
-  background-color: $neutral100;
+  background-color: var(--neutral100);
   border-radius: 20px;
   box-shadow: 0px 0px 12px 0px rgba(12, 11, 51, 0.12);
   cursor: pointer;
@@ -27,7 +27,7 @@
     }
   }
   .numberIconText {
-    color: $primary200;
+    color: var(--primary200);
   }
   .contentContainer {
     position: relative;

--- a/web/src/templates/page/sections/components/shared/dynamicCardComponent/dynamicCardComponent.module.scss
+++ b/web/src/templates/page/sections/components/shared/dynamicCardComponent/dynamicCardComponent.module.scss
@@ -100,7 +100,7 @@
         left: 0;
         border-radius: 11px;
         z-index: -1;
-        background: $neutral200;
+        background: var(--neutral200);
         @include min-width($tabletXL) {
           border-radius: 20px;
         }

--- a/web/src/templates/page/sections/components/shared/dynamicSelector/dynamicSelector.module.scss
+++ b/web/src/templates/page/sections/components/shared/dynamicSelector/dynamicSelector.module.scss
@@ -25,7 +25,7 @@
         height: 575px;
         right: -20px;
         top: 0;
-        background: $neutral200;
+        background: var(--neutral200);
         border-radius: 40px 0px 0px 40px;
         z-index: -1;
         @include min-width($mobileXL) {

--- a/web/src/templates/page/sections/components/shared/fullWidthCard/FullWidthCard.tsx
+++ b/web/src/templates/page/sections/components/shared/fullWidthCard/FullWidthCard.tsx
@@ -1,7 +1,6 @@
 import * as React from "react"
 import cx from "classnames"
 import * as styles from "./fullWidthCard.module.scss"
-import { HeadingModel } from "../../../../../../interfaces/interfaces"
 import StrapiImage from "../../../../../../components/atoms/images/StrapiImage"
 import Heading from "../Heading/Heading"
 

--- a/web/src/templates/page/sections/components/shared/fullWidthCard/fullWidthCard.module.scss
+++ b/web/src/templates/page/sections/components/shared/fullWidthCard/fullWidthCard.module.scss
@@ -30,15 +30,15 @@
     @include align-items(center);
   }
   &.whiteBackground {
-    background-color: $neutral100;
+    background-color: var(--neutral100);
     box-shadow: 0px 0px 20px 0px rgba(12, 11, 51, 0.12);
 
   }
   &.greyBackground {
-    background-color: $neutral200;
+    background-color: var(--neutral200);
   }
   &.lightPurpleBackground {
-    background-color: $primary100;
+    background-color: var(--primary100);
   }
   
 }

--- a/web/src/templates/page/sections/components/shared/headerContainer/components/formSkeleton.module.scss
+++ b/web/src/templates/page/sections/components/shared/headerContainer/components/formSkeleton.module.scss
@@ -33,7 +33,7 @@
   }
   .skeleton {
     width: 100%;
-    background: $skeletonBG;
+    background: var(--skeletonBG);
     height: 64px;
     border-radius: 8px;
     margin-bottom: 18px;
@@ -148,7 +148,7 @@
   display: block;
   width: 128px;
   height: 871px;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0), $neutral100, rgba(255, 255, 255, 0));
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0), var(--neutral100), rgba(255, 255, 255, 0));
   content: "";
   animation: skeleton-animation 2s infinite;
   @include min-width($mobileXL) {

--- a/web/src/templates/page/sections/components/shared/headerContainer/headerContainer.module.scss
+++ b/web/src/templates/page/sections/components/shared/headerContainer/headerContainer.module.scss
@@ -52,10 +52,10 @@
   }
 }
 .form__container {
-  background-color: $neutral100;
+  background-color: var(--neutral100);
   padding: 20px 20px 4px;
   border-radius: 12px;
-  box-shadow: 0px 0px 10px $boxShadowLigh;
+  box-shadow: 0px 0px 10px var(--boxShadowLigh);
   @include flexbox();
   @include flex-direction(column);
   @include justify-content(space-between);

--- a/web/src/templates/page/sections/components/shared/list/components/List.tsx
+++ b/web/src/templates/page/sections/components/shared/list/components/List.tsx
@@ -33,10 +33,10 @@ const ListComponent: React.FC<ListModel> = props => {
   }
 
   const titleSizeStyles: Record<string, string> = {
-    small: "heading7",
-    medium: "heading6",
-    large: "heading6",
-    xlarge: "heading5",
+    small: "heading7 neutral1000",
+    medium: "heading6 neutral1000",
+    large: "heading6 neutral1000",
+    xlarge: "heading5 neutral1000",
   }
 
   const colorStyles: Record<string, string> = {

--- a/web/src/templates/page/sections/components/shared/list/listGroup/listGroup.module.scss
+++ b/web/src/templates/page/sections/components/shared/list/listGroup/listGroup.module.scss
@@ -39,6 +39,7 @@
     .titleHeader {
       font-weight: 500;
       margin: 0;
+      color: var(--neutral1000);
       &.boldFontWeight {
         font-weight: 700;
       }

--- a/web/src/templates/page/sections/components/shared/sideCardsSlider/sideCardsSlider.module.scss
+++ b/web/src/templates/page/sections/components/shared/sideCardsSlider/sideCardsSlider.module.scss
@@ -158,7 +158,7 @@
         left: 0;
         top: 50%;
         transform: translateY(-50%);
-        background: $neutral200;
+        background: var(--neutral200);
         z-index: -1;
       }
       @include min-width($desktopXL) {
@@ -304,7 +304,7 @@
         right: -20px;
         top: 45%;
         transform: translateY(-50%);
-        background: $neutral200;
+        background: var(--neutral200);
         z-index: -1;
       }
     }

--- a/web/src/templates/page/sections/components/shared/stepsContent/stepsContent.module.scss
+++ b/web/src/templates/page/sections/components/shared/stepsContent/stepsContent.module.scss
@@ -21,8 +21,8 @@
       height: 120%;
       left: 50%;
       top: -10%;
-      background-image: -webkit-linear-gradient(transparent 0%, $primary700 40%, $primary700 60%, transparent 100%);
-      background: linear-gradient(transparent 0%, $primary700 40%, $primary700 60%,  transparent 100%);
+      background-image: -webkit-linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%, transparent 100%);
+      background: linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%,  transparent 100%);
       
     }
   }
@@ -38,8 +38,8 @@
       height: 240px;
       left: 50%;
       top: -250px;
-      background-image: -webkit-linear-gradient(transparent 0%, $primary700 40%, $primary700 60%, transparent 100%);
-      background: linear-gradient(transparent 0%, $primary700 40%, $primary700 60%, transparent 100%);
+      background-image: -webkit-linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%, transparent 100%);
+      background: linear-gradient(transparent 0%, var(--primary700) 40%, var(--primary700) 60%, transparent 100%);
     }
     @include min-width($tabletMD) {
       @include flexbox();
@@ -95,7 +95,7 @@
         @include flex(0, 0, 50%);
       }
       .number {
-        color: $primary100;
+        color: var(--primary100);
         font-family: $custom;
         font-style: normal;
         font-weight: 700;

--- a/web/src/templates/page/sections/components/shared/subHeading/SubHeading.tsx
+++ b/web/src/templates/page/sections/components/shared/subHeading/SubHeading.tsx
@@ -15,9 +15,9 @@ const SubHeading: React.FC<SubHeadingModel> = props => {
   }
 
   const titleSizeStyles: Record<string, string> = {
-    small: "heading6",
-    medium: "heading5",
-    large: "heading4",
+    small: "heading6 neutral1000",
+    medium: "heading5 neutral1000",
+    large: "heading4 neutral1000",
   }
 
   const contentSizeStyles: Record<string, string> = {
@@ -48,7 +48,11 @@ const SubHeading: React.FC<SubHeadingModel> = props => {
         )}
 
         {title?.length && (
-          <h4 className={cx(size ? titleSizeStyles[size] : "heading4")}>
+          <h4
+            className={cx(
+              size ? titleSizeStyles[size] : "heading4 neutral1000"
+            )}
+          >
             {title}
           </h4>
         )}

--- a/web/src/templates/page/sections/components/shared/table/table.module.scss
+++ b/web/src/templates/page/sections/components/shared/table/table.module.scss
@@ -27,7 +27,7 @@
     font-weight: 400;
     line-height: 20px;
     text-decoration: none;
-    color: $neutral700;
+    color: var(--neutral700);
   }
 
   b,
@@ -41,7 +41,7 @@
 
   
   a {
-    color: $primary700;
+    color: var(--primary700);
     font-family: $base;
   }
 

--- a/web/src/templates/page/sections/components/shared/testimonialCard/testimonialCard.module.scss
+++ b/web/src/templates/page/sections/components/shared/testimonialCard/testimonialCard.module.scss
@@ -12,13 +12,13 @@
   height: calc(100% - 80px);
   border-radius: 20px;
   &.teal {
-    background-color: $secondary100;
+    background-color: var(--secondary100);
   }
   &.purple {
-    background-color: $primary200;
+    background-color: var(--primary200);
   }
   &.pink{
-    background-color: $tertiary200;
+    background-color: var(--tertiary200);
   }
   .content__container {
     @include flexbox();

--- a/web/src/templates/page/sections/components/shared/video/video.module.scss
+++ b/web/src/templates/page/sections/components/shared/video/video.module.scss
@@ -29,7 +29,7 @@
     }
     video {
       max-width: 100%;
-      box-shadow: 0px 0px 16px 0px $boxShadowLigh;
+      box-shadow: 0px 0px 16px 0px var(--boxShadowLigh);
       @include min-width($desktopXL) {
         max-width: 982px;
       }
@@ -60,12 +60,12 @@
     }
     &.blackBackground {
       &::after {
-        background: $neutral1000;
+        background: var(--neutral1000);
       }
     }
     &.greyBackground {
       &::after {
-        background: $neutral200;
+        background: var(--neutral200);
       }
     }
   }


### PR DESCRIPTION
JIRA

[add dark theme option](https://gataca.atlassian.net/browse/DEV-4713)

DONE:

- PricingInfo: fix fullWidthCard properties
- Dark theme: 
   - LightTheme by default
   - added a boolean to Pages & homeIndex
   - Menú & Footer: added new media for logo dark theme
   - Adjusted text that didn't have a color var relation
   - Remember that all icons & logos, included those in actionsCards are uploading in Strapi for each page section

PENDING:

- Design needs to confirm the boxshadow of all the project for darkTheme
- Design needs to confirm if we need another field for certification image in Footer


RESULT:

Dark theme: https://www.dev.gataca.io/new-page/


https://github.com/user-attachments/assets/90ea3a1f-9ef8-49db-a9ea-e73da626827b


LightTheme: https://www.dev.gataca.io/products/gataca-vouch/


https://github.com/user-attachments/assets/addb7121-68ba-443b-9dae-451d7a251384

