### PR TITLE
DEV-4728: Changes in components: DynamicCard, FullWidthCard, margin. Adjustments in darkMode DS

### DIFF
--- a/admin/config/sync/admin-role.strapi-editor.json
+++ b/admin/config/sync/admin-role.strapi-editor.json
@@ -1339,7 +1339,8 @@
           "socialMediaButton.buttons",
           "socialMediaButton.brand_buttons",
           "socialMediaButton.button_icons",
-          "rightsReserved"
+          "rightsReserved",
+          "logoDarkTheme"
         ],
         "locales": [
           "en",
@@ -1399,7 +1400,8 @@
           "socialMediaButton.buttons",
           "socialMediaButton.brand_buttons",
           "socialMediaButton.button_icons",
-          "rightsReserved"
+          "rightsReserved",
+          "logoDarkTheme"
         ],
         "locales": [
           "en",
@@ -1437,7 +1439,8 @@
           "socialMediaButton.buttons",
           "socialMediaButton.brand_buttons",
           "socialMediaButton.button_icons",
-          "rightsReserved"
+          "rightsReserved",
+          "logoDarkTheme"
         ],
         "locales": [
           "en",
@@ -1748,7 +1751,8 @@
           "sections",
           "title",
           "slugURL",
-          "subPath"
+          "subPath",
+          "darkTheme"
         ],
         "locales": [
           "en",
@@ -1793,7 +1797,8 @@
           "sections",
           "title",
           "slugURL",
-          "subPath"
+          "subPath",
+          "darkTheme"
         ],
         "locales": [
           "en",
@@ -1816,7 +1821,8 @@
           "sections",
           "title",
           "slugURL",
-          "subPath"
+          "subPath",
+          "darkTheme"
         ],
         "locales": [
           "en",
@@ -2145,7 +2151,8 @@
           "languageButton.size",
           "languageButton.disabled",
           "languageButton.noPaddingText",
-          "languageButton.fullWidth"
+          "languageButton.fullWidth",
+          "logoDarkTheme"
         ],
         "locales": [
           "en",
@@ -2217,7 +2224,8 @@
           "languageButton.size",
           "languageButton.disabled",
           "languageButton.noPaddingText",
-          "languageButton.fullWidth"
+          "languageButton.fullWidth",
+          "logoDarkTheme"
         ],
         "locales": [
           "en",
@@ -2267,7 +2275,8 @@
           "languageButton.size",
           "languageButton.disabled",
           "languageButton.noPaddingText",
-          "languageButton.fullWidth"
+          "languageButton.fullWidth",
+          "logoDarkTheme"
         ],
         "locales": [
           "en",
@@ -2290,7 +2299,8 @@
           "seo.alternate_urls",
           "title",
           "slugURL",
-          "subPath"
+          "subPath",
+          "darkTheme"
         ],
         "locales": [
           "en",
@@ -2335,7 +2345,8 @@
           "seo.alternate_urls",
           "title",
           "slugURL",
-          "subPath"
+          "subPath",
+          "darkTheme"
         ],
         "locales": [
           "en",
@@ -2358,7 +2369,8 @@
           "seo.alternate_urls",
           "title",
           "slugURL",
-          "subPath"
+          "subPath",
+          "darkTheme"
         ],
         "locales": [
           "en",

--- a/admin/config/sync/admin-role.strapi-super-admin.json
+++ b/admin/config/sync/admin-role.strapi-super-admin.json
@@ -866,7 +866,8 @@
           "card.button.fullWidth",
           "card.upperIconClosed",
           "card.upperIconOpened",
-          "card.backContent"
+          "card.backContent",
+          "card.logoSlot"
         ]
       },
       "conditions": []
@@ -920,7 +921,8 @@
           "card.button.fullWidth",
           "card.upperIconClosed",
           "card.upperIconOpened",
-          "card.backContent"
+          "card.backContent",
+          "card.logoSlot"
         ]
       },
       "conditions": []
@@ -962,7 +964,8 @@
           "card.button.fullWidth",
           "card.upperIconClosed",
           "card.upperIconOpened",
-          "card.backContent"
+          "card.backContent",
+          "card.logoSlot"
         ]
       },
       "conditions": []

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.card.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.card.json
@@ -187,6 +187,20 @@
           "searchable": true,
           "sortable": true
         }
+      },
+      "logoSlot": {
+        "edit": {
+          "label": "logoSlot",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "logoSlot",
+          "searchable": false,
+          "sortable": false
+        }
       }
     },
     "layouts": {
@@ -228,6 +242,10 @@
           }
         ],
         [
+          {
+            "name": "logoSlot",
+            "size": 6
+          },
           {
             "name": "mainIcon",
             "size": 6

--- a/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.full-width-card.json
+++ b/admin/config/sync/core-store.plugin_content_manager_configuration_components##shared.full-width-card.json
@@ -104,13 +104,28 @@
           "searchable": false,
           "sortable": false
         }
+      },
+      "textAlign": {
+        "edit": {
+          "label": "textAlign",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "textAlign",
+          "searchable": true,
+          "sortable": true
+        }
       }
     },
     "layouts": {
       "list": [
         "id",
         "idItem",
-        "color"
+        "color",
+        "textAlign"
       ],
       "edit": [
         [
@@ -127,15 +142,19 @@
           {
             "name": "layout",
             "size": 6
+          },
+          {
+            "name": "sizeSlot",
+            "size": 6
           }
         ],
         [
           {
-            "name": "sizeSlot",
+            "name": "heading",
             "size": 6
           },
           {
-            "name": "heading",
+            "name": "textAlign",
             "size": 6
           }
         ],

--- a/admin/src/components/shared/card.json
+++ b/admin/src/components/shared/card.json
@@ -80,6 +80,16 @@
     },
     "backContent": {
       "type": "text"
+    },
+    "logoSlot": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false
     }
   }
 }

--- a/admin/src/components/shared/full-width-card.json
+++ b/admin/src/components/shared/full-width-card.json
@@ -49,6 +49,14 @@
         "videos",
         "audios"
       ]
+    },
+    "textAlign": {
+      "type": "enumeration",
+      "enum": [
+        "right",
+        "left"
+      ],
+      "default": "right"
     }
   }
 }

--- a/admin/src/components/shared/highlight.json
+++ b/admin/src/components/shared/highlight.json
@@ -1,7 +1,8 @@
 {
   "collectionName": "components_shared_highlights",
   "info": {
-    "displayName": "Highlight"
+    "displayName": "Highlight",
+    "description": ""
   },
   "options": {},
   "attributes": {
@@ -12,7 +13,8 @@
       "type": "enumeration",
       "enum": [
         "black",
-        "grey"
+        "grey",
+        "purple"
       ],
       "default": "black"
     },

--- a/web/src/interfaces/interfaces.tsx
+++ b/web/src/interfaces/interfaces.tsx
@@ -450,6 +450,7 @@ export interface SubHeadingModel {
   icon?: any
   title?: string
   content?: string
+  darkTheme: boolean
 }
 
 export interface HeadingModel {
@@ -497,6 +498,7 @@ export interface SubHeadingContainerModel {
   idItem?: string
   subHeading: SubHeadingModel[]
   columns?: string
+  darkTheme: boolean
 }
 
 export interface MainCardContainerModel {

--- a/web/src/interfaces/interfaces.tsx
+++ b/web/src/interfaces/interfaces.tsx
@@ -387,6 +387,7 @@ export interface CardModel {
   content?: any
   button?: ButtonModel
   backContent?: string
+  logoSlot?: any
 }
 
 export interface ActionCardModel {

--- a/web/src/styles/_colors.scss
+++ b/web/src/styles/_colors.scss
@@ -100,6 +100,10 @@
   --tealGradient: linear-gradient(180deg, var(--secondary600) 0%, var(--secondary1000) 100%);
   --tertiaryGradient: linear-gradient(180deg, var(--tertiary600) 0%, var(--tertiary1000) 100%);
 
+  // Buttons rgba Colors
+  --whiteColorOutlineBtn: rgba(255, 255, 255, 0.20);
+  --blackColorOutlineBtn: rgba(0, 0, 0, 0.20);
+  --greyColorOutlineBtn: rgba(169, 169, 172, 0.20);
 }
 
 .dark__theme {
@@ -197,5 +201,10 @@
   --primaryGradient: linear-gradient(180deg, var(--primary700) 0%, var(--primary1000) 100%);
   --tealGradient: linear-gradient(180deg, var(--secondary600) 0%, var(--secondary1000) 100%);
   --tertiaryGradient: linear-gradient(180deg, var(--tertiary600) 0%, var(--tertiary1000) 100%);
+
+  // Buttons rgba Colors
+  --whiteColorOutlineBtn: rgba(30, 30, 32, 0.20);
+  --blackColorOutlineBtn: rgba(255, 255, 255, 0.20);
+  --greyColorOutlineBtn:: rgba(140, 140, 144, 0.20);
 }
 

--- a/web/src/templates/page/sections/AllSectionsTemplate.tsx
+++ b/web/src/templates/page/sections/AllSectionsTemplate.tsx
@@ -28,7 +28,7 @@ import HighlightSubHeadingCard from "./components/shared/HighlightSubHeadingCard
 import FormLayout from "./components/shared/FormLayout/FormLayout"
 
 const AllSectionsTemplate: React.FC<PageModel> = props => {
-  const { sections, location } = props
+  const { sections, location, darkTheme } = props
 
   return sections?.map(item => {
     const {
@@ -176,6 +176,7 @@ const AllSectionsTemplate: React.FC<PageModel> = props => {
             avatarSize={avatarSize}
             sub_heading={sub_heading}
             highlightCard={highlight_card?.data?.attributes}
+            darkTheme={darkTheme}
           />
         )}
         {__component === "shared.button-options" && (
@@ -233,6 +234,7 @@ const AllSectionsTemplate: React.FC<PageModel> = props => {
             blockAlign={blockAlign}
             slotAlign={slotAlign}
             headingSlot={headingSlot?.data?.attributes}
+            darkTheme={darkTheme}
           />
         )}
         {__component === "shared.full-width-card" && (
@@ -243,6 +245,7 @@ const AllSectionsTemplate: React.FC<PageModel> = props => {
             color={color}
             layout={layout}
             sizeSlot={sizeSlot}
+            textAlign={textAlign}
           />
         )}
         {__component === "shared.text-media" && (
@@ -323,6 +326,7 @@ const AllSectionsTemplate: React.FC<PageModel> = props => {
             heading={heading?.data?.attributes}
             subHeadingContainer={sub_heading?.data?.attributes}
             fullWidthCard={fullWidthCard}
+            darkTheme={darkTheme}
           />
         )}
         {__component === "shared.form-layout" && (

--- a/web/src/templates/page/sections/components/generic/button/button.module.scss
+++ b/web/src/templates/page/sections/components/generic/button/button.module.scss
@@ -103,7 +103,7 @@
             border: 1px solid var(--neutral100);
             color: var(--neutral100);
             &:hover {
-                background-color: rgba(255, 255, 255, 0.20);
+                background-color: var(--whiteColorOutlineBtn);
             }
             &.disabled {
                 background-color: transparent;
@@ -169,14 +169,14 @@
             border: 1px solid var(--neutral1000);
             color: var(--neutral1000);
             &:hover {
-                background-color: rgba(0, 0, 0, 0.20);
+                background-color: var(--blackColorOutlineBtn);
             }
             &:focus {
-                background-color: rgba(0, 0, 0, 0.20);
+                background-color: var(--blackColorOutlineBtn);
                 box-shadow: inset 0px 0px 0px 1px var(--neutral600);
             }
             &:focus-visible {
-                background-color: rgba(0, 0, 0, 0.20);
+                background-color: var(--blackColorOutlineBtn);
                 outline: var(--neutral600) auto 1px;
             }
             &.disabled {
@@ -239,14 +239,14 @@
             border: 1px solid var(--neutral500);
             color: var(--neutral1000);
             &:hover {
-                background-color: rgba(169, 169, 172, 0.20);
+                background-color: --greyColorOutlineBtn;
             }
             &:focus {
-                background-color: rgba(169, 169, 172, 0.20);
+                background-color: --greyColorOutlineBtn;
                 box-shadow: inset 0px 0px 0px 1px var(--neutral500);
             }
             &:focus-visible {
-                background-color: rgba(169, 169, 172, 0.20);
+                background-color: --greyColorOutlineBtn;
                 outline: var(--neutral500) auto 1px;
             }
             &.disabled {

--- a/web/src/templates/page/sections/components/shared/Highlight/Highlight.tsx
+++ b/web/src/templates/page/sections/components/shared/Highlight/Highlight.tsx
@@ -18,6 +18,7 @@ const Highlight: React.FC<IHighlightProps> = props => {
   const colorStyles: Record<string, string> = {
     black: styles?.blackBackground,
     grey: styles?.greyBackground,
+    purple: styles?.purpleBackground,
   }
 
   const alignStyles: Record<string, string> = {

--- a/web/src/templates/page/sections/components/shared/Highlight/highlight.module.scss
+++ b/web/src/templates/page/sections/components/shared/Highlight/highlight.module.scss
@@ -21,6 +21,9 @@
   &.greyBackground {
     background-color: var(--neutral200);
   }
+  &.purpleBackground {
+    background-color: #4745B7;
+  }
   .alignCenter {
     padding: 100px 20px;
     @include min-width($mobileXL) {

--- a/web/src/templates/page/sections/components/shared/Highlight/highlight.module.scss.d.ts
+++ b/web/src/templates/page/sections/components/shared/Highlight/highlight.module.scss.d.ts
@@ -3,3 +3,4 @@ export const blackBackground: string
 export const greyBackground: string
 export const alignCenter: string
 export const alignBottom: string
+export const purpleBackground: string

--- a/web/src/templates/page/sections/components/shared/HighlightSubHeadingCard/HighlightSubHeadingCard.tsx
+++ b/web/src/templates/page/sections/components/shared/HighlightSubHeadingCard/HighlightSubHeadingCard.tsx
@@ -11,12 +11,14 @@ export type IHighlightSubHeadingCardProps = {
   heading?: HeadingModel
   subHeadingContainer?: any
   fullWidthCard?: any
+  darkTheme: boolean
 }
 
 const HighlightSubHeadingCard: React.FC<
   IHighlightSubHeadingCardProps
 > = props => {
-  const { idItem, heading, subHeadingContainer, fullWidthCard } = props
+  const { idItem, heading, subHeadingContainer, fullWidthCard, darkTheme } =
+    props
 
   const fullWidthCardHeadingData = fullWidthCard?.heading?.data?.attributes
   const fullWidthCardImageData = fullWidthCard?.image?.data?.attributes?.url
@@ -40,6 +42,7 @@ const HighlightSubHeadingCard: React.FC<
 
         {subHeadingContainer && (
           <SubHeadingContainer
+            darkTheme={darkTheme}
             {...subHeadingContainer}
             className={`${styles?.highlightSubHeadingCard__subHeading} ${
               fullWidthCardHeadingData || fullWidthCardImageData

--- a/web/src/templates/page/sections/components/shared/SubHeadingsLayout/SubHeadingsLayout.tsx
+++ b/web/src/templates/page/sections/components/shared/SubHeadingsLayout/SubHeadingsLayout.tsx
@@ -15,6 +15,7 @@ export type ISubHeadingsLayoutProps = {
   headingSlot?: HeadingModel
   blockAlign?: string
   slotAlign?: string
+  darkTheme: boolean
 }
 
 const SubHeadingsLayout: React.FC<ISubHeadingsLayoutProps> = props => {
@@ -26,6 +27,7 @@ const SubHeadingsLayout: React.FC<ISubHeadingsLayoutProps> = props => {
     blockAlign,
     slotAlign,
     headingSlot,
+    darkTheme,
   } = props
 
   const blockAlignStyles: Record<string, string> = {
@@ -80,6 +82,7 @@ const SubHeadingsLayout: React.FC<ISubHeadingsLayoutProps> = props => {
 
         {subHeadingContainer && (
           <SubHeadingContainer
+            darkTheme={darkTheme}
             idItem={subHeadingContainer?.idItem}
             columns={subHeadingContainer?.columns}
             subHeading={subHeadingContainer?.subHeading}

--- a/web/src/templates/page/sections/components/shared/card/Card.tsx
+++ b/web/src/templates/page/sections/components/shared/card/Card.tsx
@@ -21,6 +21,7 @@ const CardComponent: React.FC<CardModel> = props => {
     content,
     button,
     backContent,
+    logoSlot,
   } = props
 
   const iconSizeStyles: Record<string, string> = {
@@ -91,6 +92,12 @@ const CardComponent: React.FC<CardModel> = props => {
             <h1 className={`${cx("heading1")} ${styles?.numberIconText} `}>
               {numberIconText}
             </h1>
+          ) : null}
+          {logoSlot ? (
+            <StrapiImage
+              image={logoSlot ? logoSlot : null}
+              className={styles?.logoSlot}
+            />
           ) : null}
           {mainIcon ? (
             <StrapiImage

--- a/web/src/templates/page/sections/components/shared/card/card.module.scss
+++ b/web/src/templates/page/sections/components/shared/card/card.module.scss
@@ -67,7 +67,11 @@
       p {
         color: var(--neutral1000);
       }
-    } 
+    }
+    .logoSlot {
+      max-width: 100%;
+      height: auto;
+    }
   }
   
 }

--- a/web/src/templates/page/sections/components/shared/card/card.module.scss.d.ts
+++ b/web/src/templates/page/sections/components/shared/card/card.module.scss.d.ts
@@ -9,3 +9,4 @@ export const contentContainer: string
 export const contentHide: string
 export const contentShow: string
 export const backContentToShow: string
+export const logoSlot: string

--- a/web/src/templates/page/sections/components/shared/contentTable/ContentTable.tsx
+++ b/web/src/templates/page/sections/components/shared/contentTable/ContentTable.tsx
@@ -6,6 +6,7 @@ import ContentHeadingList from "../../generic/contentHeadingContainer/component/
 import SubHeadingContainer from "../subHeadingContainer/SubHeadingContainer"
 import StrapiAuthor from "./elements/strapiAuthor/StrapiAuthor"
 import HighlightCard from "./elements/highlightCard/HighlightCard"
+import { dark__theme } from "../../../../pageTemplate.module.scss"
 
 export type ISectionProps = {
   listContent: {
@@ -70,6 +71,7 @@ export type ISectionProps = {
     }
   }
   avatarSize?: string
+  darkTheme: boolean
 }
 
 const ContentTable: React.FC<ISectionProps> = props => {
@@ -80,6 +82,7 @@ const ContentTable: React.FC<ISectionProps> = props => {
     sub_heading,
     avatarSize,
     highlightCard,
+    darkTheme,
   } = props
 
   const [tableOfContentOpenedID, setTableOfContentOpened] = React.useState("")
@@ -108,6 +111,7 @@ const ContentTable: React.FC<ISectionProps> = props => {
           )}
           {sub_heading?.data?.attributes?.subHeading && (
             <SubHeadingContainer
+              darkTheme={darkTheme}
               idItem={sub_heading?.data?.attributes?.idItem}
               subHeading={sub_heading?.data?.attributes?.subHeading}
               columns={sub_heading?.data?.attributes?.columns}

--- a/web/src/templates/page/sections/components/shared/dynamicCard/DynamicCard.tsx
+++ b/web/src/templates/page/sections/components/shared/dynamicCard/DynamicCard.tsx
@@ -70,6 +70,7 @@ const DynamicCard: React.FC<ISectionProps> = props => {
       contentAlign,
       button,
       chip,
+      logoSlot,
     } = item
 
     return (
@@ -125,6 +126,12 @@ const DynamicCard: React.FC<ISectionProps> = props => {
               <h1 className={`${cx("heading1")} ${styles?.numberIconText} `}>
                 {numberIconText}
               </h1>
+            ) : null}
+            {logoSlot ? (
+              <StrapiImage
+                image={logoSlot ? logoSlot : null}
+                className={styles?.logoSlot}
+              />
             ) : null}
             {mainIcon ? (
               <StrapiImage

--- a/web/src/templates/page/sections/components/shared/dynamicCard/dynamicCard.module.scss
+++ b/web/src/templates/page/sections/components/shared/dynamicCard/dynamicCard.module.scss
@@ -29,6 +29,10 @@
   .numberIconText {
     color: var(--primary200);
   }
+  .logoSlot {
+    max-width: 100%;
+    height: auto;
+  }
   .contentContainer {
     position: relative;
     width: 100%;

--- a/web/src/templates/page/sections/components/shared/dynamicCard/dynamicCard.module.scss.d.ts
+++ b/web/src/templates/page/sections/components/shared/dynamicCard/dynamicCard.module.scss.d.ts
@@ -4,3 +4,4 @@ export const contentAlignCenter: string
 export const upperIcon: string
 export const numberIconText: string
 export const contentContainer: string
+export const logoSlot: string

--- a/web/src/templates/page/sections/components/shared/fullWidthCard/FullWidthCard.tsx
+++ b/web/src/templates/page/sections/components/shared/fullWidthCard/FullWidthCard.tsx
@@ -12,10 +12,20 @@ export type ISectionProps = {
   color?: string
   layout?: string
   sizeSlot?: string
+  textAlign?: string
 }
 
 const FullWidthCard: React.FC<ISectionProps> = props => {
-  const { className, idItem, heading, image, color, layout, sizeSlot } = props
+  const {
+    className,
+    idItem,
+    heading,
+    image,
+    color,
+    layout,
+    sizeSlot,
+    textAlign,
+  } = props
 
   const colorStyles: Record<string, string> = {
     white: styles?.whiteBackground,
@@ -32,6 +42,10 @@ const FullWidthCard: React.FC<ISectionProps> = props => {
     padding: styles?.padding,
   }
 
+  const textAlignStyles: Record<string, string> = {
+    right: styles?.textAlignRight,
+    left: styles?.textAlignLeft,
+  }
   const fullWidthCardHeadingData = heading?.data?.attributes
   const fullWidthCardImageData = image?.data?.attributes?.url
 
@@ -45,7 +59,9 @@ const FullWidthCard: React.FC<ISectionProps> = props => {
       <div
         className={`${styles.fullWidthCard__container} ${
           color ? colorStyles[color] : styles?.whiteBackground
-        } ${sizeSlot ? sizeSlotStyles[sizeSlot] : styles?.padding}`}
+        } ${sizeSlot ? sizeSlotStyles[sizeSlot] : styles?.padding} ${
+          textAlign ? textAlignStyles[textAlign] : styles?.textAlignRight
+        }`}
       >
         {image?.data?.attributes?.url && (
           <div

--- a/web/src/templates/page/sections/components/shared/fullWidthCard/fullWidthCard.module.scss
+++ b/web/src/templates/page/sections/components/shared/fullWidthCard/fullWidthCard.module.scss
@@ -40,6 +40,29 @@
   &.lightPurpleBackground {
     background-color: var(--primary100);
   }
+  &.textAlignLeft {
+    .fullWidthCard__heading {
+      @include order(0);
+      &.fullWidthCardPadding {
+        padding: 60px 40px 60px 60px;
+      }
+    }
+
+    .fullWidthCard__imageContainer {
+      @include order(1);
+    }
+    
+  }
+
+  &.textAlignRight {
+    .fullWidthCard__heading {
+      @include order(1);
+    }
+
+    .fullWidthCard__imageContainer {
+      @include order(0);
+    }
+  }
   
 }
 

--- a/web/src/templates/page/sections/components/shared/fullWidthCard/fullWidthCard.module.scss
+++ b/web/src/templates/page/sections/components/shared/fullWidthCard/fullWidthCard.module.scss
@@ -44,12 +44,38 @@
     .fullWidthCard__heading {
       @include order(0);
       &.fullWidthCardPadding {
-        padding: 60px 40px 60px 60px;
+        @include min-width($tabletMD) {
+          padding: 60px 40px 60px 60px;
+          @include flex-grow(0);
+        }
       }
     }
 
     .fullWidthCard__imageContainer {
       @include order(1);
+      &.padding {
+        &.fullWidthCardPadding {
+          @include min-width($tabletMD) {
+            padding: 60px 60px 60px 40px;
+          }
+        }
+      }
+      &.fiftyFifty, &.twentyFiveSeventyFive {
+        text-align: right;
+      }
+    }
+    .fiftyFifty {
+      @include min-width($tabletMD) {
+        padding-left: 40px;
+        padding-right: 0;
+      }
+    }
+
+    .twentyFiveSeventyFive {
+      @include min-width($tabletMD) {
+        padding-left: 40px;
+        padding-right: 0;
+      }
     }
     
   }
@@ -74,18 +100,15 @@
     padding: 60px;
   }
   &.fullWidthCardPadding {
-    padding: 60px 60px 60px 40px;
+    @include min-width($tabletMD) {
+      padding: 60px 60px 60px 40px;
+    }
   }
   &.fiftyFifty {
     @include order(0);
     @include min-width($tabletMD) {
       @include order(1);
-      width: calc(50% - 80px);
-      @include flex(0, 0, calc(50% - 80px));
-      @include flex-grow(1);
-    }
-    @include min-width($desktopMD) {
-      width: calc(50% - 120px);
+      width: calc(50% - 100px);
       @include flex(0, 0, calc(50% - 100px));
       @include flex-grow(1);
     }
@@ -94,15 +117,12 @@
     @include order(0);
     @include min-width($tabletMD) {
       @include order(1);
-      width: calc(75% - 80px);
-      @include flex(0, 0, calc(75% - 80px));
+      width: calc(75% - 200px);
+      @include flex(0, 0, calc(75% - 200px));
       @include flex-grow(1);
     }
-  
-    @include min-width($desktopMD) {
-      width: calc(75% - 120px);
-      @include flex(0, 0, calc(75% - 120px));
-      @include flex-grow(1);
+    &.fullWidthCardPadding {
+      @include flex-grow(0);
     }
   }
 }
@@ -131,32 +151,32 @@
     }
   }
   &.padding {
-    width: calc(100% - 80px);
+    width: calc(100% - 100px);
     padding: 40px;
     @include min-width($desktopMD) {
       padding: 60px;
+      margin: inherit;
     }
     &.fullWidthCardPadding {
-      padding: 60px 40px 60px 60px;
+      @include min-width($tabletMD) {
+        padding: 60px 40px 60px 60px;
+      }
     }
     &.fiftyFifty {
       @include min-width($tabletMD) {
-        width: calc(50% - 80px);
-        @include flex(0, 0, calc(50% - 80px));
-      }
-      @include min-width($desktopMD) {
         width: calc(50% - 100px);
         @include flex(0, 0, calc(50% - 100px));
+        @include flex-grow(1);
       }
     }
     &.twentyFiveSeventyFive {
       @include min-width($tabletMD) {
-        width: calc(25% - 80px);
-        @include flex(0, 0, calc(25% - 80px));
+      width: calc(25% - 0px);
+        @include flex(0, 0, calc(25% - 0px));
+        @include flex-grow(1);
       }
-      @include min-width($desktopMD) {
-        width: calc(25% - 100px);
-        @include flex(0, 0, calc(25% - 100px));
+      &.fullWidthCardPadding {
+        @include flex-grow(0);
       }
     }
   }

--- a/web/src/templates/page/sections/components/shared/fullWidthCard/fullWidthCard.module.scss.d.ts
+++ b/web/src/templates/page/sections/components/shared/fullWidthCard/fullWidthCard.module.scss.d.ts
@@ -11,3 +11,5 @@ export const twentyFiveSeventyFive: string
 export const padding: string
 export const fullWidthCardPadding: string
 export const imageCentered: string
+export const textAlignRight: string
+export const textAlignLeft: string

--- a/web/src/templates/page/sections/components/shared/subHeading/SubHeading.tsx
+++ b/web/src/templates/page/sections/components/shared/subHeading/SubHeading.tsx
@@ -5,8 +5,16 @@ import { SubHeadingModel } from "../../../../../../interfaces/interfaces"
 import StrapiImage from "../../../../../../components/atoms/images/StrapiImage"
 
 const SubHeading: React.FC<SubHeadingModel> = props => {
-  const { idSubHeading, size, align, icon, numberIconText, title, content } =
-    props
+  const {
+    idSubHeading,
+    size,
+    align,
+    icon,
+    numberIconText,
+    title,
+    content,
+    darkTheme,
+  } = props
 
   const iconSizeStyles: Record<string, string> = {
     small: "iconSM",
@@ -35,7 +43,11 @@ const SubHeading: React.FC<SubHeadingModel> = props => {
     <div id={idSubHeading} className={`${styles?.subheading__container} `}>
       <div className={`${align ? alignStyles[align] : styles?.alignLeft}`}>
         {numberIconText ? (
-          <h1 className={cx("heading1 primary200")}>{numberIconText}</h1>
+          <h1
+            className={cx("heading1", darkTheme ? "primary700" : "primary200")}
+          >
+            {numberIconText}
+          </h1>
         ) : null}
         {icon?.data?.attributes?.url && (
           <div>

--- a/web/src/templates/page/sections/components/shared/subHeading/subHeading.module.scss.d.ts
+++ b/web/src/templates/page/sections/components/shared/subHeading/subHeading.module.scss.d.ts
@@ -1,3 +1,4 @@
 export const subheading__container: string
 export const alignCenter: string
 export const alignLeft: string
+export const number__icon__text: string

--- a/web/src/templates/page/sections/components/shared/subHeadingContainer/SubHeadingContainer.tsx
+++ b/web/src/templates/page/sections/components/shared/subHeadingContainer/SubHeadingContainer.tsx
@@ -5,7 +5,7 @@ import * as styles from "./subHeadingContainer.module.scss"
 import SubHeading from "../subHeading/SubHeading"
 
 const SubHeadingContainer: React.FC<SubHeadingContainerModel> = props => {
-  const { className, idItem, columns, subHeading } = props
+  const { className, idItem, columns, subHeading, darkTheme } = props
 
   const columnStyles: Record<string, string> = {
     one: styles?.oneColumn,
@@ -22,7 +22,13 @@ const SubHeadingContainer: React.FC<SubHeadingContainerModel> = props => {
       )} ${className && className}`}
     >
       {subHeading?.map((item: any, index: number) => {
-        return <SubHeading key={`subHeading__` + index} {...item} />
+        return (
+          <SubHeading
+            key={`subHeading__` + index}
+            {...item}
+            darkTheme={darkTheme}
+          />
+        )
       })}
     </div>
   )


### PR DESCRIPTION

JIRA:

[Changes in components: DynamicCard, Card, FullWidthCard, roles permits & adjustments in darkMode DS](https://gataca.atlassian.net/browse/DEV-4728)

DONE:

- FullWidthCard: have option of textAlign right [DS](https://www.figma.com/design/KT2IKvsPLSuX0keXXFCprD/Design-System---WEBSITE?node-id=8446-28126&m=dev). Adjustment of sizes according to DS

- DarkTheme changes according to [DS](https://www.figma.com/design/ZaLWsGc7xbXXeN6ViYjnLu/DESKTOP---Website-Design-5.0-(01%2F23)?node-id=9565-5656&m=dev): 
   - buttons on hover colors 
   - Highlight Component: have purple color -> the buttons don't go according to the colors theme, so must been created for now for darkTheme with the opposite color
   - SubHeadings: fixed colors according to theme -> [darkTheme](https://www.figma.com/design/ZaLWsGc7xbXXeN6ViYjnLu/DESKTOP---Website-Design-5.0-(01%2F23)?node-id=9580-44358&m=dev) & [whiteTheme](https://www.figma.com/design/ZaLWsGc7xbXXeN6ViYjnLu/DESKTOP---Website-Design-5.0-(01%2F23)?node-id=9341-38749&m=dev)

- Cards & DynamicCards: option to have logoSlot [DS](https://www.figma.com/design/KT2IKvsPLSuX0keXXFCprD?node-id=8198-13438#1103279177) 

RESULT:

- Changes FullWidthCard & DarkTheme changes: https://www.dev.gataca.io/gaming/

https://github.com/user-attachments/assets/730c1d6d-1938-4447-938c-99c765369e4e

- Cards & DynamicCards https://www.dev.gataca.io/new-page/

![Screenshot 2025-02-27 at 18 18 25](https://github.com/user-attachments/assets/dae83b1f-d6c3-4b83-a187-6dbf3b598325)

